### PR TITLE
Pass just the length

### DIFF
--- a/newspaper/nlp.py
+++ b/newspaper/nlp.py
@@ -168,26 +168,25 @@ def sentence_position(i, size):
     probability of being an important sentence.
     """
     normalized =  i*1.0 / size
-    if (normalized > 0 and normalized <= 0.1):
-        return 0.17
-    elif normalized > 0.1 and normalized <= 0.2:
-        return 0.23
-    elif (normalized > 0.2 and normalized <= 0.3):
-        return 0.14
-    elif (normalized > 0.3 and normalized <= 0.4):
-        return 0.08
-    elif (normalized > 0.4 and normalized <= 0.5):
-        return 0.05
-    elif (normalized > 0.5 and normalized <= 0.6):
-        return 0.04
-    elif (normalized > 0.6 and normalized <= 0.7):
-        return 0.06
-    elif (normalized > 0.7 and normalized <= 0.8):
-        return 0.04
-    elif (normalized > 0.8 and normalized <= 0.9):
-        return 0.04
-    elif (normalized > 0.9 and normalized <= 1.0):
+    if (normalized > 0.9 && and normalized <= 1.0):
         return 0.15
-    else:
+    elif (normalized > 0.8):
+        return 0.04
+    elif (normalized > 0.7):
+        return 0.04
+    elif (normalized > 0.6):
+        return 0.06
+    elif (normalized > 0.5):
+        return 0.04
+    elif (normalized > 0.4):
+        return 0.05
+    elif (normalized > 0.3):
+        return 0.08
+    elif (normalized > 0.2):
+        return 0.14
+    elif (normalized > 0.1):
+        return 0.23
+    elif (normalized > 0):
+        return 0.17
+    else
         return 0
-


### PR DESCRIPTION
In length_score only the length is needed why pass the whole string ?
