### PR TITLE
Extract Meta Tags in structured way

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -101,6 +101,9 @@ class Article(object):
         # meta favicon field in HTML source
         self.meta_favicon = u""
 
+        # Meta tags contain a lot of structured data like OpenGraph
+        self.meta_data = {}
+
         # The canonical link of this article if found in the meta data
         self.canonical_link = u""
 
@@ -179,6 +182,9 @@ class Article(object):
 
         meta_keywords = self.extractor.get_meta_keywords(self)
         self.set_meta_keywords(meta_keywords)
+
+        meta_data = self.extractor.get_meta_data(self)
+        self.set_meta_data(meta_data)
 
         # TODO self.publish_date = self.config.publishDateExtractor.extract(self.doc)
 
@@ -455,6 +461,9 @@ class Article(object):
         """
         """
         self.meta_description = meta_description
+
+    def set_meta_data(self, meta_data):
+        self.meta_data = meta_data
 
     def set_canonical_link(self, canonical_link):
         """


### PR DESCRIPTION
There is a lot of meta data that poeple put in meta tags. Espcially
when you realize that Open Graph, and Twitter Cards are very popular.
Therefore I suggest that should be a way to extract the tags from
an article.

Here is an example:

``` sh
import newspaper
article = newspaper.build_article('http://www.buzzfeed.com/tabirakhter/epic-literary-love-tattoos')
article.download()
article.parse()
print pprint.pformat(dict(article.meta_data))

{'article': {'publisher': 'https://www.facebook.com/BuzzFeed',
             'section': 'DIY',
             'tag': 'Tattoos'},
 'og': {'description': 'All is fair in love and ink.',
        'image': {'height': 625,
                  'url': 'http://s3-ak.buzzfeed.com/static/2014-01/enhanced/webdr06/22/16/enhanced-buzz-8304-1390426280-19.jpg',
                  'width': 625},
        'site_name': 'BuzzFeed',
        'title': '23 Epic Literary Love Tattoos',
        'type': 'article',
        'url': 'http://www.buzzfeed.com/tabirakhter/epic-literary-love-tattoos'},
 'twitter': {'app': {'id': {'googleplay': 'com.buzzfeed.android',
                            'ipad': 'id352969997',
                            'iphone': 'id352969997'},
                     'url': {'googleplay': 'http://www.buzzfeed.com/tabirakhter/epic-literary-love-tattoos'}},
             'card': 'summary_large_image',
             'creator': '@tabooradley',
             'description': 'All is fair in love and ink.',
             'image': 'http://s3-ak.buzzfeed.com/static/2014-01/campaign_images/webdr06/26/14/23-epic-literary-love-tattoos-1-1410-1390763440-3_big.jpg',
             'site': '@buzzfeed',
             'title': '23 Epic Literary Love Tattoos',
             'url': 'http://www.buzzfeed.com/tabirakhter/epic-literary-love-tattoos'}}
```
