### PR TITLE
Fix reddit top image

### DIFF
--- a/newspaper/utils/__init__.py
+++ b/newspaper/utils/__init__.py
@@ -268,6 +268,8 @@ def clear_memo_cache(source):
 def encodeValue(value):
     """
     """
+    if value is None:
+        return u''
     string_org = value
     try:
         value = smart_unicode(value)


### PR DESCRIPTION
Article.py set_reddit_top_img never works as self.top_img is not empty string in any case. 

``` python
 def set_reddit_top_img(self):
        if self.top_img != u'': # if we already have a top img...
            return
        # select image with top size
```

Reason is simple set_top_img could encode None to "None" string:

``` python
  def set_top_img(self, src_url):
        src_url = encodeValue(src_url)
        self.top_img = src_url
        self.top_image = src_url
```
