### PR TITLE
Use unittest assert methods

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -68,13 +68,13 @@ class ArticleTestCase(unittest.TestCase):
 
     @print_test
     def test_url(self):
-        assert self.article.url == u'http://www.cnn.com/2013/11/27/travel/weather-thanksgiving/index.html'
+        self.assertEqual(self.article.url, u'http://www.cnn.com/2013/11/27/travel/weather-thanksgiving/index.html')
 
     @print_test
     def test_download_html(self):
         self.article.download()
         # can't compare html because it changes on every page as time goes on
-        assert len(self.article.html) > 5000
+        self.assertGreater(len(self.article.html), 5000)
 
     @print_test
     def test_pre_download_parse(self):
@@ -96,12 +96,12 @@ class ArticleTestCase(unittest.TestCase):
 
         self.article.parse()
         with open(os.path.join(TEST_DIR, 'data/body_example.txt'), 'r') as f:
-            assert self.article.text == f.read()
-        assert self.article.top_img == TOP_IMG
-        assert self.article.authors == AUTHORS
-        assert self.article.title == TITLE
+            self.assertEqual(self.article.text, f.read())
+        self.assertEqual(self.article.top_img, TOP_IMG)
+        self.assertEqual(self.article.authors, AUTHORS)
+        self.assertEqual(self.article.title, TITLE)
         print 'we now have ', len(self.article.imgs), 'images'
-        assert len(self.article.imgs) == LEN_IMGS
+        self.assertEqual(len(self.article.imgs), LEN_IMGS)
 
     @print_test
     def test_pre_parse_nlp(self):
@@ -125,8 +125,8 @@ class ArticleTestCase(unittest.TestCase):
         self.article.nlp()
         # print self.article.summary
         # print self.article.keywords
-        assert self.article.summary == SUMMARY
-        assert self.article.keywords == KEYWORDS
+        self.assertEqual(self.article.summary, SUMMARY)
+        self.assertEqual(self.article.keywords, KEYWORDS)
 
 class SourceTestCase(unittest.TestCase):
     def runTest(self):
@@ -156,8 +156,8 @@ class SourceTestCase(unittest.TestCase):
         s.clean_memo_cache()
         s.build()
 
-        assert s.brand == BRAND
-        assert s.description == DESC
+        self.assertEqual(s.brand, BRAND)
+        self.assertEqual(s.description, DESC)
 
         # For this test case and a few more, I don't believe you can actually
         # assert two values to equal eachother because some values are ever changing.
@@ -186,7 +186,7 @@ class SourceTestCase(unittest.TestCase):
         saved_urls = s.category_urls()
         s.categories = [] # reset and try again with caching
         s.set_categories()
-        assert sorted(s.category_urls()) == sorted(saved_urls)
+        self.assertEqual(sorted(s.category_urls()), sorted(saved_urls))
 
 class UrlTestCase(unittest.TestCase):
     def runTest(self):
@@ -209,10 +209,10 @@ class UrlTestCase(unittest.TestCase):
         for tup in test_tuples:
             lst = int(tup[0])
             url = tup[1]
-            assert len(tup) == 2
+            self.assertEqual(len(tup), 2)
             truth_val = True if lst == 1 else False
             try:
-                assert truth_val == valid_url(url, test=True)
+                self.assertEqual(truth_val, valid_url(url, test=True))
             except AssertionError, e:
                 print '\t\turl: %s is supposed to be %s' % (url, truth_val)
                 raise
@@ -236,13 +236,13 @@ class APITestCase(unittest.TestCase):
     @print_test
     def test_source_build(self):
         huff_paper = newspaper.build('http://www.huffingtonpost.com/', dry=True)
-        assert isinstance(huff_paper, Source) == True
+        self.assertIsInstance(huff_paper, Source)
 
     @print_test
     def test_article_build(self):
         url = 'http://abcnews.go.com/blogs/politics/2013/12/states-cite-surge-in-obamacare-sign-ups-ahead-of-first-deadline/'
         article = newspaper.build_article(url)
-        assert isinstance(article, Article) == True
+        self.assertIsInstance(article, Article)
         article.download()
         article.parse()
         article.nlp()
@@ -274,18 +274,18 @@ class EncodingTestCase(unittest.TestCase):
 
     @print_test
     def test_encode_val(self):
-        assert encodeValue(self.uni_string) == self.uni_string
-        assert encodeValue(self.normal_string) == u'∆ƒˆƒ´´lucas yang'
+        self.assertEqual(encodeValue(self.uni_string), self.uni_string)
+        self.assertEqual(encodeValue(self.normal_string), u'∆ƒˆƒ´´lucas yang')
 
     @print_test
     def test_smart_unicode(self):
-        assert smart_unicode(self.uni_string) == self.uni_string
-        assert smart_unicode(self.normal_string) == u'∆ƒˆƒ´´lucas yang'
+        self.assertEqual(smart_unicode(self.uni_string), self.uni_string)
+        self.assertEqual(smart_unicode(self.normal_string), u'∆ƒˆƒ´´lucas yang')
 
     @print_test
     def test_smart_str(self):
-        assert smart_str(self.uni_string) == "∆ˆˆø∆ßåßlucas yang˜"
-        assert smart_str(self.normal_string) == "∆ƒˆƒ´´lucas yang"
+        self.assertEqual(smart_str(self.uni_string), "∆ˆˆø∆ßåßlucas yang˜")
+        self.assertEqual(smart_str(self.normal_string), "∆ƒˆƒ´´lucas yang")
 
 
 class MThreadingTestCase(unittest.TestCase):
@@ -325,41 +325,41 @@ class ConfigBuildTestCase(unittest.TestCase):
         Test if our **kwargs to config building setup actually works.
         """
         a = Article(url='http://www.cnn.com/2013/11/27/travel/weather-thanksgiving/index.html')
-        assert a.config.language == 'en'
-        assert a.config.memoize_articles == True
-        assert a.config.use_meta_language == True
+        self.assertEqual(a.config.language, 'en')
+        self.assertTrue(a.config.memoize_articles)
+        self.assertTrue(a.config.use_meta_language)
 
         a = Article(url='http://www.cnn.com/2013/11/27/travel/weather-thanksgiving/index.html',
                 language='zh', memoize_articles=False)
-        assert a.config.language == 'zh'
-        assert a.config.memoize_articles == False
-        assert a.config.use_meta_language == False
+        self.assertEqual(a.config.language, 'zh')
+        self.assertFalse(a.config.memoize_articles)
+        self.assertFalse(a.config.use_meta_language)
 
         s = Source(url='http://cnn.com')
-        assert s.config.language == 'en'
-        assert s.config.MAX_FILE_MEMO == 20000
-        assert s.config.memoize_articles == True
-        assert s.config.use_meta_language == True
+        self.assertEqual(s.config.language, 'en')
+        self.assertEqual(s.config.MAX_FILE_MEMO, 20000)
+        self.assertTrue(s.config.memoize_articles)
+        self.assertTrue(s.config.use_meta_language)
 
         s = Source(url="http://cnn.com", memoize_articles=False,
                 MAX_FILE_MEMO=10000, language='en')
-        assert s.config.memoize_articles == False
-        assert s.config.MAX_FILE_MEMO == 10000
-        assert s.config.language == 'en'
-        assert s.config.use_meta_language == False
+        self.assertFalse(s.config.memoize_articles)
+        self.assertEqual(s.config.MAX_FILE_MEMO, 10000)
+        self.assertEqual(s.config.language, 'en')
+        self.assertFalse(s.config.use_meta_language)
 
         s = newspaper.build('http://cnn.com', dry=True)
-        assert s.config.language == 'en'
-        assert s.config.MAX_FILE_MEMO == 20000
-        assert s.config.memoize_articles == True
-        assert s.config.use_meta_language == True
+        self.assertEqual(s.config.language, 'en')
+        self.assertEqual(s.config.MAX_FILE_MEMO, 20000)
+        self.assertTrue(s.config.memoize_articles)
+        self.assertTrue(s.config.use_meta_language)
 
         s = newspaper.build('http://cnn.com', dry=True, memoize_articles=False,
                 MAX_FILE_MEMO=10000, language='zh')
-        assert s.config.language == 'zh'
-        assert s.config.MAX_FILE_MEMO == 10000
-        assert s.config.memoize_articles == False
-        assert s.config.use_meta_language == False
+        self.assertEqual(s.config.language, 'zh')
+        self.assertEqual(s.config.MAX_FILE_MEMO, 10000)
+        self.assertFalse(s.config.memoize_articles)
+        self.assertFalse(s.config.use_meta_language)
 
 class MultiLanguageTestCase(unittest.TestCase):
     def runTest(self):
@@ -374,7 +374,7 @@ class MultiLanguageTestCase(unittest.TestCase):
         article.download()
         article.parse()
         with codecs.open(os.path.join(TEXT_FN, 'chinese_text_1.txt'), 'r', 'utf8') as f:
-            assert article.text == f.read()
+            self.assertEqual(article.text, f.read())
 
         # with codecs.open(os.path.join(HTML_FN, 'chinese_html_1.html'), 'w', 'utf8') as f:
         #    f.write(article.html)
@@ -386,7 +386,7 @@ class MultiLanguageTestCase(unittest.TestCase):
         article.download()
         article.parse()
         with codecs.open(os.path.join(TEXT_FN, 'arabic_text_1.txt'), 'r', 'utf8') as f:
-            assert article.text == f.read()
+            self.assertEqual(article.text, f.read())
 
         # with codecs.open(os.path.join(HTML_FN, 'arabic_html_1.html'), 'w', 'utf8') as f:
         #    f.write(article.html)
@@ -398,7 +398,7 @@ class MultiLanguageTestCase(unittest.TestCase):
         article.download()
         article.parse()
         with codecs.open(os.path.join(TEXT_FN, 'spanish_text_1.txt'), 'r', 'utf8') as f:
-            assert article.text == f.read()
+            self.assertEqual(article.text, f.read())
 
         # with codecs.open(os.path.join(HTML_FN, 'spanish_html_1.html'), 'w', 'utf8') as f:
         #    f.write(article.html)


### PR DESCRIPTION
This patch replaces the `assert ...` lines in `unit_test.py` with [the assert methods from python's unittest library](http://docs.python.org/2/library/unittest.html#assert-methods). This makes the tests give useful error messages when they fail.

Incidentally, the tests do fail when I run them (see below). I'd like to hack on the library, but I'd be nice to have the tests pass first. Could you point me in the right direction?

```
$ python tests/unit_tests.py
    testing function 'test_config_build'
    [OK] in 'test_config_build' 0.02 sec
.   testing function 'test_chinese_fulltext_extract'
Building Trie..., from /Users/omar/dev/newspaper/newspaper/packages/jieba/dict.txt
loading model from cache /var/folders/t9/2_t3ywb917772b0lkp0lvt900000gn/T/jieba.cache
loading model cost  1.59256482124 seconds.
Trie has been built succesfully.
Etesting source unit
    testing function 'source_url_input_none'
    [OK] in 'source_url_input_none' 0.00 sec
    testing function 'test_cache_categories'
    [OK] in 'test_cache_categories' 2.53 sec
    testing function 'test_source_build'
F   testing function 'test_encode_val'
    [OK] in 'test_encode_val' 0.00 sec
    testing function 'test_smart_unicode'
    [OK] in 'test_smart_unicode' 0.00 sec
    testing function 'test_smart_str'
    [OK] in 'test_smart_str' 0.00 sec
.testing url unit
    testing function 'test_valid_urls'
    [OK] in 'test_valid_urls' 0.00 sec
.testing article unit
    testing function 'test_url'
    [OK] in 'test_url' 0.00 sec
    testing function 'test_download_html'
    [OK] in 'test_download_html' 2.96 sec
    testing function 'test_pre_download_parse'
You must download() an article before parsing it!
    [OK] in 'test_pre_download_parse' 0.00 sec
    testing function 'test_parse_html'
we now have  48 images
Ftesting API unit
    testing function 'test_article_build'
    [OK] in 'test_article_build' 8.26 sec
    testing function 'test_hot_trending'
    [OK] in 'test_hot_trending' 1.83 sec
    testing function 'test_popular_urls'
    [OK] in 'test_popular_urls' 0.00 sec
.
======================================================================
ERROR: runTest (__main__.MultiLanguageTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit_tests.py", line 366, in runTest
    self.test_chinese_fulltext_extract()
  File "tests/unit_tests.py", line 36, in run
    method(*args, **kw)
  File "tests/unit_tests.py", line 375, in test_chinese_fulltext_extract
    article.parse()
  File "/Users/omar/dev/newspaper/tests/../newspaper/article.py", line 214, in parse
    self.fetch_images()
  File "/Users/omar/dev/newspaper/tests/../newspaper/article.py", line 222, in fetch_images
    self.set_meta_img(meta_img_url)
  File "/Users/omar/dev/newspaper/tests/../newspaper/article.py", line 423, in set_meta_img
    self.set_top_img(src_url)
  File "/Users/omar/dev/newspaper/tests/../newspaper/article.py", line 428, in set_top_img
    if s.satisfies_requirements(src_url):
  File "/Users/omar/dev/newspaper/tests/../newspaper/images.py", line 221, in satisfies_requirements
    dimension = fetch_image_dimension(img_url, self.useragent, referer=self.url)
  File "/Users/omar/dev/newspaper/tests/../newspaper/images.py", line 158, in fetch_image_dimension
    return fetch_url(url, useragent, referer, retries, dimension=True)
  File "/Users/omar/dev/newspaper/tests/../newspaper/images.py", line 120, in fetch_url
    p.feed(new_data)
  File "/Users/omar/dev/newspaper/venv/lib/python2.7/site-packages/PIL/ImageFile.py", line 383, in feed
    if flag or len(im.tile) != 1:
TypeError: object of type 'NoneType' has no len()

======================================================================
FAIL: runTest (__main__.SourceTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit_tests.py", line 136, in runTest
    self.test_source_build()
  File "tests/unit_tests.py", line 36, in run
    method(*args, **kw)
  File "tests/unit_tests.py", line 160, in test_source_build
    self.assertEqual(s.description, DESC)
AssertionError: u'CNN.com International delivers breaking news from across the globe and information on the latest top stories, business, sports and entertainment headlines. Follow the news as it happens through: special reports, videos, audio, photo galleries plus interactive maps and timelines.' != 'CNN.com delivers the latest breaking news and information on the latest top stories, weather, business, entertainment, politics, and more. For in-depth coverage, CNN.com provides special reports, video, audio, photo galleries, and interactive guides.'

======================================================================
FAIL: runTest (__main__.ArticleTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit_tests.py", line 55, in runTest
    self.test_parse_html()
  File "tests/unit_tests.py", line 36, in run
    method(*args, **kw)
  File "tests/unit_tests.py", line 104, in test_parse_html
    self.assertEqual(len(self.article.imgs), LEN_IMGS)
AssertionError: 48 != 47

----------------------------------------------------------------------
Ran 7 tests in 53.733s

FAILED (failures=2, errors=1)
```
