### PR TITLE
removed quotes of 'filename' in utils\__init__.py

### DIFF
--- a/newspaper/utils/__init__.py
+++ b/newspaper/utils/__init__.py
@@ -32,7 +32,7 @@ log.setLevel(logging.DEBUG)
 class FileHelper(object):
     @classmethod
     def loadResourceFile(self, filename):
-        if not os.path.isabs('filename'):
+        if not os.path.isabs(filename):
             # _PARENT_DIR = os.path.join(_TEST_DIR, '../..') # packages/goose
             # dirpath = os.path.dirname(goose.__file__)
             dirpath = os.path.abspath(os.path.dirname(__file__)) # goose/utils


### PR DESCRIPTION
Hi codelucas, this should be a small errata. I think the single quotes should be removed. Could you verify please?
