### PR TITLE
Meta tag extraction fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ Pillow==2.5.1
 PyYAML==3.11
 cssselect==0.9.1
 lxml==3.3.5
-mock==1.0.1
 nltk==2.0.4
 requests==2.3.0
 six==1.7.3
-git+https://github.com/karls/responses@regex-url-matching
+-e git+https://github.com/karls/responses@regex-url-matching#egg=responses

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -237,12 +237,12 @@ class SourceTestCase(unittest.TestCase):
         s = Source(url)
         s.download()
         s.parse()
-        # s.set_categories()
+        s.set_categories()
 
-        # saved_urls = s.category_urls()
-        # s.categories = [] # reset and try again with caching
-        # s.set_categories()
-        # assert sorted(s.category_urls()) == sorted(saved_urls)
+        saved_urls = s.category_urls()
+        s.categories = [] # reset and try again with caching
+        s.set_categories()
+        assert sorted(s.category_urls()) == sorted(saved_urls)
 
 class UrlTestCase(unittest.TestCase):
     def runTest(self):


### PR DESCRIPTION
I discovered that extracting <meta> information from the HTML was a bit broken -- at least I couldn't get it to work properly. The `article.meta_data` dict contained the following after parsing:

``` python
defaultdict(<type 'dict'>,
{'CPS_SITE_NAME': {},
 'application-name': {},
 'Headline': {},
 'IFS_URL': {},
 'Section': {},
 'UKFS_URL': {},
 'CPS_AUDIENCE': {},
 'msapplication-task': {},
 'Description': {},
 'CPS_ID': {},
 'CPS_PLATFORM': {},
 'msapplication-TileColor': {},
 'contentFlavor': {},
 'msapplication-window': {},
 'CPS_SECTION_PATH': {},
 'twitter': {'card': 'summary'},
 'bbcsearch_noindex': {},
 'msapplication-tooltip': {},
 'CPS_ASSET_TYPE': {},
 'msapplication-TileImage': {},
 'msapplication-starturl': {},
 'viewport': {},
 'OriginalPublicationDate': {},
 'og': {'url': 'http://www.bbc.co.uk/news/world-africa-16377824',
        'site_name': 'BBC News',
        'image': 'http://news.bbcimg.co.uk/media/images/57644000/jpg/_57644047_armed-lou-nuer-youth-in-lik.jpg',
        'type': 'article',
        'title': "'More troops' to South Sudan town"},
 'THUMBNAIL_URL': {}})
```

Only `og`, `twitter` etc keys were parsed correctly. This patch fixes this bug and all the keys are correctly parsed.
