### PR TITLE
split title with _ 

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -30,6 +30,7 @@ ESCAPED_FRAGMENT_REPLACEMENT = StringReplacement(
 TITLE_REPLACEMENTS = ReplaceSequence().create(u"&raquo;").append(u"»")
 PIPE_SPLITTER = StringSplitter("\\|")
 DASH_SPLITTER = StringSplitter(" - ")
+UNDERSCORE_SPLITTER = StringSplitter("_")
 ARROWS_SPLITTER = StringSplitter("»")
 COLON_SPLITTER = StringSplitter(":")
 SPACE_SPLITTER = StringSplitter(' ')
@@ -180,6 +181,11 @@ class ContentExtractor(object):
         # split title with -
         if not used_delimeter and '-' in title_text:
             title_text = self.split_title(title_text, DASH_SPLITTER)
+            used_delimeter = True
+
+        # split title with _
+        if not used_delimeter and '_' in title_text:
+            title_text = self.split_title(title_text, UNDERSCORE_SPLITTER)
             used_delimeter = True
 
         # split title with »


### PR DESCRIPTION
1. I found some sites contained underscore in title section, so I think we add split title with undersocre for good.
2. Usually, we just want to download one category, instead of all categories. 
