### PR TITLE
Fixed #78: Remove encoding tag because lxml won't accept it for unicode

### DIFF
--- a/newspaper/parsers.py
+++ b/newspaper/parsers.py
@@ -10,6 +10,7 @@ import logging
 import lxml.etree
 import lxml.html
 import lxml.html.clean
+import re
 
 from copy import deepcopy
 
@@ -43,6 +44,10 @@ class Parser(object):
     def fromstring(cls, html):
         html = utils.encodeValue(html)
         try:
+            # Remove encoding tag because lxml won't accept it for unicode objects (Issue #78)
+            if html.startswith('<?'):
+                html = re.sub(r'^\<\?.*?\?\>', '', html, flags=re.DOTALL)
+
             cls.doc = lxml.html.fromstring(html)
         except Exception, e:
             print '[Parse lxml ERR]', str(e)


### PR DESCRIPTION
lxml apparently doesn't accept unicode objects with both an encoding specified and an encoding tag in the HTML document, because they're paranoid that the two won't match (why they can't just check whether they match, I have no idea). Stripped encoding tag before calling lxml.html.fromstring()

@codelucas, please merge this into master as well.
