### PR TITLE
Fixed empty return in top_meta_image

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -316,7 +316,9 @@ class ContentExtractor(object):
 
         top_meta_image = try_one or try_two or try_three or try_four
 
-        return urllib.parse.urljoin(article_url, top_meta_image)
+        if top_meta_image:
+            return urllib.parse.urljoin(article_url, top_meta_image)
+        return u''
 
     def get_meta_type(self, doc):
         """Returns meta type of article, open graph protocol


### PR DESCRIPTION
Return empty unicode in ContentExtractor.top_meta_image() when no image is found. It was returning the article's url.

Example:
http://www.usnews.com/news/entertainment/articles/2015/01/15/boyhood-keaton-moore-are-oscar-favorites-in-vegas
(note that USNews often updates its articles, e.g. by adding an image -- at the time of writing it was without images)