### PR TITLE
Fixed nodeToString() to return valid HTML

### DIFF
--- a/newspaper/parsers.py
+++ b/newspaper/parsers.py
@@ -85,7 +85,7 @@ class Parser(object):
         """`decode` is needed at the end because `etree.tostring`
         returns a python bytestring
         """
-        return lxml.etree.tostring(node).decode()
+        return lxml.etree.tostring(node, method='html').decode()
 
     @classmethod
     def replaceTag(cls, node, tag):


### PR DESCRIPTION
In some cases the output of nodeToString() is not valid HTML, e.g. for iframe nodes.

Solution found here: http://stackoverflow.com/questions/27020950/lxml-modify-tags-prevent

An example of bad behavior is an article with a youtube video inside. The video embed code is transformed into `<iframe ... />`, that is not valid, and thus the result in the browser is a page with no visible content after the video.