### PR TITLE
bumping nltk to 2.0.5 - see #824 in nltk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Pillow==2.5.1
 PyYAML==3.11
 cssselect==0.9.1
 lxml==3.3.5
-nltk==2.0.4
+nltk==2.0.5
 requests==2.3.0
 six==1.7.3
 jieba==0.35


### PR DESCRIPTION
This has to be done due to https://github.com/nltk/nltk/issues/824