### PR TITLE
Add python3-pip install step for Ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,10 @@ package name is ``newspaper``.
 
 **If you are on Debian / Ubuntu**, install using the following:
 
+- Install ``pip3`` command needed to install ``newspaper3k`` package::
+
+    $ sudo apt-get install python3-pip
+
 - Python development version, needed for Python.h::
 
     $ sudo apt-get install python-dev


### PR DESCRIPTION
Without `sudo apt-get install python3-pip` as an additional step, `pip3` command would not be available.

```
$ pip3 install newspaper3k
The program 'pip3' is currently not installed. You can install it by typing:
sudo apt-get install python3-pip
```