### PR TITLE
Use children of suspected author element

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -20,6 +20,8 @@ import urllib.parse
 
 from tldextract import tldextract
 
+from lxml import etree
+
 from . import urls
 
 from .utils import ReplaceSequence, StringReplacement, StringSplitter
@@ -143,7 +145,7 @@ class ContentExtractor(object):
                 if len(mm) > 0:
                     content = mm[0]
             else:
-                content = match.text or ''
+                content = match.text or ''.join([str(etree.tostring(c)) for c in match.getchildren()])
             if len(content) > 0:
                 _authors.extend(parse_byline(content))
 


### PR DESCRIPTION
This may maybe solve issue #147

I'm sorry if it breaks anything else, I tried to make it keep the old behaviour : the ''.join(...) will give '' if there are no children, and it is not evaluated if the .text attribute is not empty.