### PR TITLE
bugfix in article.py, is_valid_body

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -269,7 +269,8 @@ class Article(object):
         wordcount = self.text.split(' ')
         sentcount = self.text.split('.')
 
-        if meta_type == 'article' and wordcount > (self.config.MIN_WORD_COUNT):
+        if (meta_type == 'article' and len(wordcount) >
+                (self.config.MIN_WORD_COUNT)):
             log.debug('%s verified for article and wc' % self.url)
             return True
 


### PR DESCRIPTION
Hi  - small fix in article.py, `is_valid_body` (compared `wordcount` rather than `len(wordcount)` against `MIN_WORD_COUNT`)