### PR TITLE
Updated requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyYAML==3.11
 cssselect==0.9.1
 lxml==3.3.5
 nltk==2.0.5
-requests==2.3.0
+requests==2.6.0
 six==1.7.3
 jieba==0.35
 feedparser==5.1.3


### PR DESCRIPTION
Proposing an update because requests-2.3.0 is creating an error for me on ubuntu 15.10
( like this one : https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=770157 )
I tried updating pyssl, urllib3 and such but only updating requests is working...