### PR TITLE
Handle lxml raising ValueError on node.itertext() - Python 3

### DIFF
--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -8,8 +8,12 @@ __license__ = 'MIT'
 __copyright__ = 'Copyright 2014, Lucas Ou-Yang'
 
 from html.parser import HTMLParser
+import logging
 
 from .text import innerTrim
+
+
+log = logging.getLogger(__name__)
 
 
 class OutputFormatter(object):
@@ -62,6 +66,7 @@ class OutputFormatter(object):
             try:
                 txt = self.parser.getText(node)
             except ValueError:  # lxml error
+                log.warning('Error parsing lxml node', exc_info=True)
                 txt = None
 
             if txt:

--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -59,7 +59,11 @@ class OutputFormatter(object):
     def convert_to_text(self):
         txts = []
         for node in list(self.get_top_node()):
-            txt = self.parser.getText(node)
+            try:
+                txt = self.parser.getText(node)
+            except ValueError:  # lxml error
+                txt = None
+
             if txt:
                 txt = HTMLParser().unescape(txt)
                 txt_lis = innerTrim(txt).split(r'\n')


### PR DESCRIPTION
Same as #144 but on the Python3 branch.