### PR TITLE
Added nltk named entities feature

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -73,6 +73,9 @@ class Article(object):
         # `keywords` are extracted via nlp() from the body text
         self.keywords = []
 
+        # `named entities` are extracted via nlp() from the body text
+        self.named_entities = []
+
         # `meta_keywords` are extracted via parse() from <meta> tags
         self.meta_keywords = []
 
@@ -325,6 +328,9 @@ class Article(object):
         summary = '\n'.join(summary_sents)
         self.set_summary(summary)
 
+        named_entities = nlp.named_entities(self.text)
+        self.set_named_entities(named_entities)
+
     def get_parse_candidate(self):
         """A parse candidate is a wrapper object holding a link hash of this
         article and a final_url of the article
@@ -436,6 +442,14 @@ class Article(object):
             raise Exception("Keyword input must be list!")
         if keywords:
             self.keywords = keywords[:self.config.MAX_KEYWORDS]
+
+    def set_named_entities(self, named_entities):
+        """named    entities are stored in list format
+        """
+        if not isinstance(named_entities, list):
+            raise Exception("Named entities input must be list!")
+        if named_entities:
+            self.named_entities = named_entities[:self.config.MAX_NAMED_ENTITIES]
 
     def set_authors(self, authors):
         """Authors are in ["firstName lastName", "firstName lastName"] format

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -27,13 +27,14 @@ class Configuration(object):
         Modify any of these Article / Source properties
         TODO: Have a seperate ArticleConfig and SourceConfig extend this!
         """
-        self.MIN_WORD_COUNT = 300  # num of word tokens in text
-        self.MIN_SENT_COUNT = 7    # num of sentence tokens
-        self.MAX_TITLE = 200       # num of chars
-        self.MAX_TEXT = 100000     # num of chars
-        self.MAX_KEYWORDS = 35     # num of strings in list
-        self.MAX_AUTHORS = 10      # num strings in list
-        self.MAX_SUMMARY = 5000    # num of chars
+        self.MIN_WORD_COUNT = 300    # num of word tokens in text
+        self.MIN_SENT_COUNT = 7      # num of sentence tokens
+        self.MAX_TITLE = 200         # num of chars
+        self.MAX_TEXT = 100000       # num of chars
+        self.MAX_KEYWORDS = 35       # num of strings in list
+        self.MAX_NAMED_ENTITIES = 35 # num of strings in list
+        self.MAX_AUTHORS = 10        # num strings in list
+        self.MAX_SUMMARY = 5000      # num of chars
 
         # max number of urls we cache for each news source
         self.MAX_FILE_MEMO = 20000

--- a/newspaper/nlp.py
+++ b/newspaper/nlp.py
@@ -142,6 +142,37 @@ def split_sentences(text):
     sentences = [x.replace('\n', '') for x in sentences if len(x) > 10]
     return sentences
 
+def chunked_sentences(text):
+    """Splits a large string into chunked sentences [http://www.nltk.org/book/ch07.html#chunking]
+    """
+    import nltk
+    sentences = split_sentences(text)
+    tokenized_sentences = [nltk.word_tokenize(sentence) for sentence in sentences]
+    tagged_sentences = [nltk.pos_tag(sentence) for sentence in tokenized_sentences]
+    chunked_sentences = nltk.ne_chunk_sents(tagged_sentences, binary=True)
+    return chunked_sentences
+
+def extract_entity_names(tree):
+    """ Extracts named entities from a nltk chunked tree
+    """
+    entity_names = []
+    if hasattr(tree, 'label'):
+        if tree.label() == 'NE':
+            entity_names.append(' '.join([child[0] for child in tree]))
+        else:
+            for child in tree:
+                entity_names.extend(extract_entity_names(child))
+    return entity_names
+
+def named_entities(text):
+    """ Get all the named entities
+    """
+    entity_names = []
+    chunked = chunked_sentences(text)
+    for tree in chunked:
+        entity_names.extend(extract_entity_names(tree))
+    entity_names = list(set(entity_names))
+    return entity_names
 
 def length_score(sentence_len):
     return 1 - math.fabs(ideal - sentence_len) / ideal
@@ -188,3 +219,4 @@ def sentence_position(i, size):
         return 0.17
     else:
         return 0
+


### PR DESCRIPTION
Along with ```article.keywords```,
we can now get all the named entities of the article by typing ```article.named_entities```
I thought this might be useful !