### PR TITLE
Fix installation and build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
- - "3.2"
  - "3.3"
  - "3.4"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
  - "3.3"
  - "3.4"
+ - "3.5"
 install:
  - pip install -r requirements.txt
  - python download_corpora.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ requests>=2.3.0
 six>=1.7.3
 feedparser>=5.1.3
 tldextract>=1.5.1
-feedfinder2>=0.0.1
+feedfinder2==0.0.1
 jieba3k>=0.35.1
 python-dateutil>=2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ requests>=2.3.0
 six>=1.7.3
 feedparser>=5.1.3
 tldextract>=1.5.1
-feedfinder2==0.0.1
+feedfinder2>=0.0.4
 jieba3k>=0.35.1
 python-dateutil>=2.4.0


### PR DESCRIPTION
* Upgrade feedfinder2 version to fix installation (due to dfm/feedfinder2#5).
* Drop support for Python 3.2 (end of life in February 2016 and causing errors with some packages).
* Test on Python 3.5.