### PR TITLE
Improve title parsing

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -237,6 +237,7 @@ class ContentExtractor(object):
         2. h1 similar to og:title, use h1
         3. title contains h1, title contains og:title, len(h1) > len(og:title), use h1
         4. title starts with og:title, use og:title
+        5. use title, after splitting
         """
         title = ''
         title_element = self.parser.getElementsByTag(doc, tag='title')
@@ -315,12 +316,6 @@ class ContentExtractor(object):
         if not used_delimeter and ' » ' in title_text:
             title_text = self.split_title(title_text, ARROWS_SPLITTER, title_text_h1)
             used_delimeter = True
-
-        # deleted as too often removes relevant parts of the title
-        # split title with :
-        # if not used_delimeter and ':' in title_text:
-        #     title_text = self.split_title(title_text, COLON_SPLITTER, title_text_h1)
-        #     used_delimeter = True
 
         title = MOTLEY_REPLACEMENT.replaceAll(title_text)
 

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -306,6 +306,7 @@ class ContentExtractor(object):
         # split title with _
         if not used_delimeter and '_' in title_text:
             title_text = self.split_title(title_text, UNDERSCORE_SPLITTER, title_text_h1)
+            used_delimeter = True
 
         # split title with /
         if not used_delimeter and '/' in title_text:

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -224,6 +224,20 @@ class ContentExtractor(object):
 
     def get_title(self, doc):
         """Fetch the article title and analyze it
+
+        Assumptions:
+        - title tag is the most reliable (inherited from Goose)
+        - h1, if properly detected, is the best (visible to users)
+        - og:title and h1 can help improve the title extraction
+        - python == is too strict, often we need to compare fitlered
+          versions, i.e. lowercase and ignoring special chars
+
+        Explicit rules:
+        1. title == h1, no need to split
+        2. h1 similar to og:title, use h1
+        3. title contains h1, title contains og:title, len(h1) > len(og:title), use h1
+        4. title starts with og:title, use og:title
+        5. title starts with h1 and h1 long enough, use h1
         """
         title = ''
         title_element = self.parser.getElementsByTag(doc, tag='title')
@@ -235,48 +249,116 @@ class ContentExtractor(object):
         title_text = self.parser.getText(title_element[0])
         used_delimeter = False
 
+        # title from h1
+        # - extract the longest text from all h1 elements
+        # - too short texts (less than 2 words) are discarded
+        # - clean double spaces
+        title_text_h1 = ''
+        title_element_h1_list = self.parser.getElementsByTag(doc, tag='h1') or []
+        title_text_h1_list = [self.parser.getText(tag) for tag in title_element_h1_list]
+        if title_text_h1_list:
+            # sort by len and set the longest
+            title_text_h1_list.sort(key=len, reverse=True)
+            title_text_h1 = title_text_h1_list[0]
+            # discard too short texts
+            if len(title_text_h1.split(' ')) <= 2:
+                title_text_h1 = ''
+            # clean double spaces
+            title_text_h1 = ' '.join([x for x in title_text_h1.split() if x])
+
+        # title from og:title
+        title_text_fb = self.get_meta_content(doc, 'meta[property="og:title"]')
+        if not title_text_fb:
+            title_text_fb = self.get_meta_content(doc, 'meta[name="og:title"]')
+        if not title_text_fb:
+            title_text_fb = ''
+
+        # create filtered versions of title_text, title_text_h1, title_text_fb
+        # for finer comparison
+        filter_regex = re.compile(r'[^a-zA-Z0-9\ ]')
+        filter_title_text = filter_regex.sub('', title_text).lower()
+        filter_title_text_h1 = filter_regex.sub('', title_text_h1).lower()
+        filter_title_text_fb = filter_regex.sub('', title_text_fb).lower()
+        words_title_text_h1 = len(title_text_h1.split(' '))
+
+        # check for better alternatives for title_text and possibly skip splitting
+        if title_text_h1 == title_text:
+            used_delimeter = True
+        elif filter_title_text_h1 and filter_title_text_h1 == filter_title_text_fb:
+            title_text = title_text_h1
+            used_delimeter = True
+        elif filter_title_text_h1 and filter_title_text_h1 in filter_title_text \
+            and filter_title_text_fb and filter_title_text_fb in filter_title_text \
+            and len(title_text_h1) > len(title_text_fb):
+            title_text = title_text_h1
+            used_delimeter = True
+        elif filter_title_text_fb and filter_title_text_fb != filter_title_text \
+            and filter_title_text.startswith(filter_title_text_fb):
+            title_text = title_text_fb
+            used_delimeter = True
+        elif filter_title_text_h1 and filter_title_text_h1 != filter_title_text \
+            and filter_title_text.startswith(filter_title_text_h1) and words_title_text_h1 >= 4:
+            title_text = title_text_h1
+            used_delimeter = True
+
         # split title with |
-        if '|' in title_text:
-            title_text = self.split_title(title_text, PIPE_SPLITTER)
+        if not used_delimeter and '|' in title_text:
+            title_text = self.split_title(title_text, PIPE_SPLITTER, title_text_h1)
             used_delimeter = True
 
         # split title with -
         if not used_delimeter and '-' in title_text:
-            title_text = self.split_title(title_text, DASH_SPLITTER)
+            title_text = self.split_title(title_text, DASH_SPLITTER, title_text_h1)
             used_delimeter = True
 
         # split title with _
         if not used_delimeter and '_' in title_text:
-            title_text = self.split_title(title_text, UNDERSCORE_SPLITTER)
+            title_text = self.split_title(title_text, UNDERSCORE_SPLITTER, title_text_h1)
 
         # split title with /
         if not used_delimeter and '/' in title_text:
-            title_text = self.split_title(title_text, SLASH_SPLITTER)
+            title_text = self.split_title(title_text, SLASH_SPLITTER, title_text_h1)
             used_delimeter = True
 
         # split title with »
         if not used_delimeter and ' » ' in title_text:
-            title_text = self.split_title(title_text, ARROWS_SPLITTER)
+            title_text = self.split_title(title_text, ARROWS_SPLITTER, title_text_h1)
             used_delimeter = True
 
+        # deleted as too often removes relevant parts of the title
         # split title with :
-        if not used_delimeter and ':' in title_text:
-            title_text = self.split_title(title_text, COLON_SPLITTER)
-            used_delimeter = True
+        # if not used_delimeter and ':' in title_text:
+        #     title_text = self.split_title(title_text, COLON_SPLITTER, title_text_h1)
+        #     used_delimeter = True
 
         title = MOTLEY_REPLACEMENT.replaceAll(title_text)
+
+        # in some cases the final title is quite similar to title_text_h1
+        # (either it differs for case, for special chars, or it's truncated)
+        # in these cases, we prefer the title_text_h1
+        filter_title = filter_regex.sub('', title).lower()
+        if filter_title_text_h1 == filter_title or filter_title_text_h1.startswith(filter_title):
+            title = title_text_h1
+
         return title
 
-    def split_title(self, title, splitter):
+    def split_title(self, title, splitter, hint=None):
         """Split the title to best part possible
         """
         large_text_length = 0
         large_text_index = 0
         title_pieces = splitter.split(title)
 
+        if hint:
+            filter_regex = re.compile(r'[^a-zA-Z0-9\ ]')
+            hint = filter_regex.sub('', hint).lower()
+
         # find the largest title piece
         for i in range(len(title_pieces)):
-            current = title_pieces[i]
+            current = title_pieces[i].strip()
+            if hint and hint in filter_regex.sub('', current).lower():
+                large_text_index = i
+                break
             if len(current) > large_text_length:
                 large_text_length = len(current)
                 large_text_index = i

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -237,7 +237,6 @@ class ContentExtractor(object):
         2. h1 similar to og:title, use h1
         3. title contains h1, title contains og:title, len(h1) > len(og:title), use h1
         4. title starts with og:title, use og:title
-        5. title starts with h1 and h1 long enough, use h1
         """
         title = ''
         title_element = self.parser.getElementsByTag(doc, tag='title')
@@ -276,7 +275,6 @@ class ContentExtractor(object):
         filter_title_text = filter_regex.sub('', title_text).lower()
         filter_title_text_h1 = filter_regex.sub('', title_text_h1).lower()
         filter_title_text_fb = filter_regex.sub('', title_text_fb).lower()
-        words_title_text_h1 = len(title_text_h1.split(' '))
 
         # check for better alternatives for title_text and possibly skip splitting
         if title_text_h1 == title_text:
@@ -292,10 +290,6 @@ class ContentExtractor(object):
         elif filter_title_text_fb and filter_title_text_fb != filter_title_text \
                 and filter_title_text.startswith(filter_title_text_fb):
             title_text = title_text_fb
-            used_delimeter = True
-        elif filter_title_text_h1 and filter_title_text_h1 != filter_title_text \
-                and filter_title_text.startswith(filter_title_text_h1) and words_title_text_h1 >= 4:
-            title_text = title_text_h1
             used_delimeter = True
 
         # split title with |
@@ -334,7 +328,7 @@ class ContentExtractor(object):
         # (either it differs for case, for special chars, or it's truncated)
         # in these cases, we prefer the title_text_h1
         filter_title = filter_regex.sub('', title).lower()
-        if filter_title_text_h1 == filter_title or filter_title_text_h1.startswith(filter_title):
+        if filter_title_text_h1 == filter_title:
             title = title_text_h1
 
         return title

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -267,11 +267,8 @@ class ContentExtractor(object):
             title_text_h1 = ' '.join([x for x in title_text_h1.split() if x])
 
         # title from og:title
-        title_text_fb = self.get_meta_content(doc, 'meta[property="og:title"]')
-        if not title_text_fb:
-            title_text_fb = self.get_meta_content(doc, 'meta[name="og:title"]')
-        if not title_text_fb:
-            title_text_fb = ''
+        title_text_fb = (self.get_meta_content(doc, 'meta[property="og:title"]') or
+                         self.get_meta_content(doc, 'meta[name="og:title"]') or '')
 
         # create filtered versions of title_text, title_text_h1, title_text_fb
         # for finer comparison
@@ -288,16 +285,16 @@ class ContentExtractor(object):
             title_text = title_text_h1
             used_delimeter = True
         elif filter_title_text_h1 and filter_title_text_h1 in filter_title_text \
-            and filter_title_text_fb and filter_title_text_fb in filter_title_text \
-            and len(title_text_h1) > len(title_text_fb):
+                and filter_title_text_fb and filter_title_text_fb in filter_title_text \
+                and len(title_text_h1) > len(title_text_fb):
             title_text = title_text_h1
             used_delimeter = True
         elif filter_title_text_fb and filter_title_text_fb != filter_title_text \
-            and filter_title_text.startswith(filter_title_text_fb):
+                and filter_title_text.startswith(filter_title_text_fb):
             title_text = title_text_fb
             used_delimeter = True
         elif filter_title_text_h1 and filter_title_text_h1 != filter_title_text \
-            and filter_title_text.startswith(filter_title_text_h1) and words_title_text_h1 >= 4:
+                and filter_title_text.startswith(filter_title_text_h1) and words_title_text_h1 >= 4:
             title_text = title_text_h1
             used_delimeter = True
 

--- a/newspaper/parsers.py
+++ b/newspaper/parsers.py
@@ -12,6 +12,7 @@ import lxml.html
 import lxml.html.clean
 import re
 import traceback
+from html.parser import HTMLParser
 
 from bs4 import UnicodeDammit
 from copy import deepcopy
@@ -244,7 +245,9 @@ class Parser(object):
     @classmethod
     def getAttribute(cls, node, attr=None):
         if attr:
-            return node.attrib.get(attr, None)
+            attr = node.attrib.get(attr, None)
+        if attr:
+            attr = HTMLParser().unescape(attr)
         return attr
 
     @classmethod


### PR DESCRIPTION
This is @ecesena's work from PR #113 which I tweaked it a bit and tested.

Significant changes to #113 (the rest of the info is there): 

* Unescape html attributes. This fixes html entities appearing in og tags (og:title specifically).
* Title parsing - don't rely on h1 if long then title and og:title (often the added part is junk).

**Testing:**

I made a hacky title dump script to run over the fulltext articles urls and compared the results manually. On this subset of articles, this version gives the best results (although not perfect).

The results in an ugly spreadsheet here: https://docs.google.com/spreadsheets/d/1eUakaWAdldyjFd-cp-OaqmI-vUCgooXQfLZcmcsATa8/edit?usp=sharing

Contains the follwoing sheets:

1. "Fulltext titles" the same articles as in fulltext tests - went over these manually.
2. "short titles" - articles/pages from my projects database, that had short urls. these are usually parsed wrong so I compared the 2 versions of the script on those. There are over 500 results with different titles so I didn't compare them manually, but in overall, it looks like the new version is better.

Color codes:

* Green - good result
* Yellow - not the best but acceptable
* Red - wrong.

(Adding extra columns would be more efficient, but this was the quickest way I could think of)

@codelucas if you could review that would be great.

If anyone has any ideas of how to improve and/or test this, let me know :)