### PR TITLE
 Adding setting for num of sentences in summary

### DIFF
--- a/docs/user_guide/advanced.rst
+++ b/docs/user_guide/advanced.rst
@@ -211,6 +211,8 @@ Here is a full list of the configuration options:
 
 ``MAX_SUMMARY``, default 5000, "num of chars of the summary"
 
+``MAX_SUMMARY_SENT``, default 5, "num of sentences in summary"
+
 ``MAX_FILE_MEMO``, default 20000, "python setup.py sdist bdist_wininst upload"
 
 ``memoize_articles``, default True, "cache and save articles run after run"

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -173,11 +173,7 @@ class Article(object):
         output_formatter = OutputFormatter(self.config)
 
         title = self.extractor.get_title(self.clean_doc)
-        """if title has successfully extracted, 
-        override any existing title
-        """
-        if title is not None:
-            self.set_title(title)
+        self.set_title(title)
 
         authors = self.extractor.get_authors(self.clean_doc)
         self.set_authors(authors)

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -321,7 +321,9 @@ class Article(object):
         keyws = list(set(title_keyws + text_keyws))
         self.set_keywords(keyws)
 
-        summary_sents = nlp.summarize(title=self.title, text=self.text)
+        max_sents = self.config.MAX_SUMMARY_SENT
+
+        summary_sents = nlp.summarize(title=self.title, text=self.text, max_sents=max_sents)
         summary = '\n'.join(summary_sents)
         self.set_summary(summary)
 

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -141,13 +141,16 @@ class Article(object):
         self.parse()
         self.nlp()
 
-    def download(self, html=None):
+    def download(self, html=None, title=None):
         """Downloads the link's HTML content, don't use if you are batch async
         downloading articles
         """
         if html is None:
             html = network.get_html(self.url, self.config)
         self.set_html(html)
+
+        if title is not None:
+            self.set_title(title)
 
     def parse(self):
         if not self.is_downloaded:
@@ -170,7 +173,11 @@ class Article(object):
         output_formatter = OutputFormatter(self.config)
 
         title = self.extractor.get_title(self.clean_doc)
-        self.set_title(title)
+        """if title has successfully extracted, 
+        override any existing title
+        """
+        if title is not None:
+            self.set_title(title)
 
         authors = self.extractor.get_authors(self.clean_doc)
         self.set_authors(authors)

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -34,6 +34,7 @@ class Configuration(object):
         self.MAX_KEYWORDS = 35     # num of strings in list
         self.MAX_AUTHORS = 10      # num strings in list
         self.MAX_SUMMARY = 5000    # num of chars
+        self.MAX_SUMMARY_SENT = 5  # num of sentences
 
         # max number of urls we cache for each news source
         self.MAX_FILE_MEMO = 20000

--- a/newspaper/nlp.py
+++ b/newspaper/nlp.py
@@ -20,8 +20,8 @@ with open(settings.NLP_STOPWORDS_EN, 'r') as f:
 ideal = 20.0
 
 
-def summarize(url='', title='', text=''):
-    if (text == '' or title == ''):
+def summarize(url='', title='', text='', max_sents=5):
+    if (text == '' or title == '' or max_sents <= 0):
         return []
 
     summaries = []
@@ -29,8 +29,8 @@ def summarize(url='', title='', text=''):
     keys = keywords(text)
     titleWords = split_words(title)
 
-    # Score setences, and use the top 5 sentences
-    ranks = score(sentences, titleWords, keys).most_common(5)
+    # Score setences, and use the top 5 or max_sents sentences
+    ranks = score(sentences, titleWords, keys).most_common(max_sents)
     for rank in ranks:
         summaries.append(rank[0])
     return summaries


### PR DESCRIPTION
Updated version of PR #129 by @mehuleo, plus minor changes and docs.

> Sometime if Article is too long, 5 line summary will not do justice! So adding an extra setting in Configuration using this, one can set number of summary sentences.

The original branch isn't there anymore so I applied the commits with `git am`. Looks like it worked fine.