### PR TITLE
Ignore punctuation when calculating link density

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -863,18 +863,20 @@ class ContentExtractor(object):
         link to text ratio, then the text is less likely to be relevant
         """
         links = self.parser.getElementsByTag(e, tag='a')
-        if links is None or len(links) == 0:
+        if not links:
             return False
 
         text = self.parser.getText(e)
-        words = text.split(' ')
+        words = filter(lambda word: word.isalnum(), text.split())
+        if not words:
+            return True
         words_number = float(len(words))
         sb = []
         for link in links:
             sb.append(self.parser.getText(link))
 
         linkText = ''.join(sb)
-        linkWords = linkText.split(' ')
+        linkWords = linkText.split()
         numberOfLinkWords = float(len(linkWords))
         numberOfLinks = float(len(links))
         linkDivisor = float(numberOfLinkWords / words_number)

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -867,7 +867,7 @@ class ContentExtractor(object):
             return False
 
         text = self.parser.getText(e)
-        words = filter(lambda word: word.isalnum(), text.split())
+        words = [word for word in text.split() if word.isalnum()]
         if not words:
             return True
         words_number = float(len(words))


### PR DESCRIPTION
When calculating link density, punctuation characters should not count as words.
This could be if a paragraph consists of a single link followed by punctuation such as a full stop.
The punctation could also consist of multiple characters such as an ellipsis.
In that case it should still be regarding as a having a high density of links.