### PR TITLE
get_canonical_link() method - return og:url if available

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -435,12 +435,12 @@ class ContentExtractor(object):
         return data
 
     def get_canonical_link(self, article_url, doc):
-        """If the article has meta canonical link set in the url
-        """
-        kwargs = {'tag': 'link', 'attr': 'rel', 'value': 'canonical'}
-        meta = self.parser.getElementsByTag(doc, **kwargs)
-        if meta is not None and len(meta) > 0:
-            href = self.parser.getAttribute(meta[0], 'href')
+        """If the article has meta canonical link set in the url"""
+
+        link = self.parser.getElementsByTag(doc, tag='link', attr='rel', value='canonical')
+
+        if link:
+            href = self.parser.getAttribute(link[0], 'href')
             if href:
                 href = href.strip()
                 o = urllib.parse.urlparse(href)

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -435,21 +435,33 @@ class ContentExtractor(object):
         return data
 
     def get_canonical_link(self, article_url, doc):
-        """If the article has meta canonical link set in the url"""
+        """
+        Return the article's canonical URL
 
-        link = self.parser.getElementsByTag(doc, tag='link', attr='rel', value='canonical')
+        Gets the first available value of:
+        1. The rel=canonical tag
+        2. The og:url tag
+        """
 
-        if link:
-            href = self.parser.getAttribute(link[0], 'href')
-            if href:
-                href = href.strip()
-                o = urllib.parse.urlparse(href)
-                if not o.hostname:
-                    z = urllib.parse.urlparse(article_url)
-                    domain = '%s://%s' % (z.scheme, z.hostname)
-                    href = urllib.parse.urljoin(domain, href)
-                return href
-        return ''
+        result = ''
+
+        links = self.parser.getElementsByTag(doc, tag='link', attr='rel', value='canonical')
+        canonical = self.parser.getAttribute(links[0], 'href') if links else ''
+
+        og_url = self.get_meta_content(doc, 'meta[property="og:url"]')
+
+        if canonical:
+            canonical = canonical.strip()
+            o = urllib.parse.urlparse(canonical)
+            if not o.hostname:
+                z = urllib.parse.urlparse(article_url)
+                domain = '%s://%s' % (z.scheme, z.hostname)
+                canonical = urllib.parse.urljoin(domain, canonical)
+            result = canonical
+        elif og_url:
+            result = og_url  # fallback to og:url tag, must be the full url
+
+        return result
 
     def get_img_urls(self, article_url, doc):
         """Return all of the images on an html page, lxml root


### PR DESCRIPTION
As proposed in #175 

If `rel=canonical` is not available, try to get the open graph equivalent: `og:url`.
