### PR TITLE
Fixed logging messages and level + comment fix.

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -371,10 +371,12 @@ class Article(object):
         except TypeError as e:
             if "Can't convert 'NoneType' object to str implicitly" in e.args[0]:
                 log.debug("No pictures found. Top image not set, %s" % e)
+            elif "timed out" in e.args[0]:
+                log.debug("Download of picture timed out. Top image not set, %s" % e)
             else:
-                log.debug('TypeError other than None type error. Cannot set top image using the Reddit algorithm., %s' % e)
+                log.critical('TypeError other than None type error. Cannot set top image using the Reddit algorithm. Possible error with PIL., %s' % e)
         except Exception as e:
-            log.debug('Other error with setting top image using the Reddit algorithm., %s' % e)
+            log.critical('Other error with setting top image using the Reddit algorithm. Possible error with PIL, %s' % e)
 
     def set_title(self, title):
         if self.title and not title:

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -363,7 +363,7 @@ class Article(object):
 
     def set_reddit_top_img(self):
         """Wrapper for setting images. Queries known image attributes
-        first, then uses Reddit's imgage algorithm as a fallback.
+        first, then uses Reddit's image algorithm as a fallback.
         """
         try:
             s = images.Scraper(self)
@@ -372,9 +372,9 @@ class Article(object):
             if "Can't convert 'NoneType' object to str implicitly" in e.args[0]:
                 log.debug("No pictures found. Top image not set, %s" % e)
             else:
-                log.critical('jpeg error with PIL, %s' % e)
+                log.debug('TypeError other than None type error. Cannot set top image using the Reddit algorithm., %s' % e)
         except Exception as e:
-            log.critical('jpeg error with PIL, %s' % e)
+            log.debug('Other error with setting top image using the Reddit algorithm., %s' % e)
 
     def set_title(self, title):
         if self.title and not title:


### PR DESCRIPTION
In the function set_reddit_top_img of article.py I edited the logging messages such that they made more sense, as well as not giving it such a high logging level. We were getting critical errors about "jpeg error with PIL, timed out". However, it seemed like it was simply images.py which was having a time out issue when downloading images for dimension measuring. I don't believe it had anything to do with PIL.