### PR TITLE
Fix #208 - parsing exceptions

### DIFF
--- a/newspaper/cleaners.py
+++ b/newspaper/cleaners.py
@@ -225,8 +225,9 @@ class DocumentCleaner(object):
                 bad_divs += 1
             elif div is not None:
                 replace_nodes = self.get_replacement_nodes(doc, div)
+                replace_nodes = [n for n in replace_nodes if n is not None]
                 div.clear()
-                for c, n in enumerate(replace_nodes):
-                    div.insert(c, n)
+                for i, node in enumerate(replace_nodes):
+                    div.insert(i, node)
                 else_divs += 1
         return doc


### PR DESCRIPTION
DocumentCleaner.div_to_para() - filter out empty nodes
If the Parser fails to parse a node it returns None, which causes an exception on `div.insert(i, node)`

Fixes #208 