### PR TITLE
Improved title splitting and tests

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -22,14 +22,14 @@ from tldextract import tldextract
 
 from . import urls
 
-from .utils import ReplaceSequence, StringReplacement, StringSplitter
+from .utils import StringReplacement, StringSplitter
 
 log = logging.getLogger(__name__)
 
 MOTLEY_REPLACEMENT = StringReplacement("&#65533;", "")
 ESCAPED_FRAGMENT_REPLACEMENT = StringReplacement(
     "#!", "?_escaped_fragment_=")
-TITLE_REPLACEMENTS = ReplaceSequence().create("&raquo;").append("»")
+TITLE_REPLACEMENTS = StringReplacement("&raquo;", "»")
 PIPE_SPLITTER = StringSplitter("\\|")
 DASH_SPLITTER = StringSplitter(" - ")
 UNDERSCORE_SPLITTER = StringSplitter("_")

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -34,7 +34,7 @@ PIPE_SPLITTER = StringSplitter("\\|")
 DASH_SPLITTER = StringSplitter(" - ")
 UNDERSCORE_SPLITTER = StringSplitter("_")
 SLASH_SPLITTER = StringSplitter("/")
-ARROWS_SPLITTER = StringSplitter("»")
+ARROWS_SPLITTER = StringSplitter(" » ")
 COLON_SPLITTER = StringSplitter(":")
 SPACE_SPLITTER = StringSplitter(' ')
 NO_STRINGS = set()
@@ -255,7 +255,7 @@ class ContentExtractor(object):
             used_delimeter = True
 
         # split title with »
-        if not used_delimeter and '»' in title_text:
+        if not used_delimeter and ' » ' in title_text:
             title_text = self.split_title(title_text, ARROWS_SPLITTER)
             used_delimeter = True
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -298,6 +298,26 @@ class ArticleTestCase(unittest.TestCase):
         self.assertCountEqual(KEYWORDS, self.article.keywords)
 
 
+class ContentExtractorTestCase(unittest.TestCase):
+    """Test specific element extraction cases"""
+
+    def setUp(self):
+        self.extractor = newspaper.extractors.ContentExtractor(Configuration())
+        self.parser = newspaper.parsers.Parser
+
+    def _get_title(self, html):
+        doc = self.parser.fromstring(html)
+        return self.extractor.get_title(doc)
+
+    def test_get_title_basic(self):
+        html = '<title>Test title</title>'
+        assert self._get_title(html) == 'Test title'
+
+    def test_get_title_split(self):
+        html = '<title>Test page » Test title</title>'
+        assert self._get_title(html) == 'Test title'
+
+
 class SourceTestCase(unittest.TestCase):
     @print_test
     def test_source_url_input_none(self):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -317,6 +317,10 @@ class ContentExtractorTestCase(unittest.TestCase):
         html = '<title>Test page » Test title</title>'
         assert self._get_title(html) == 'Test title'
 
+    def test_get_title_split_escaped(self):
+        html = '<title>Test page &raquo; Test title</title>'
+        assert self._get_title(html) == 'Test title'
+
 
 class SourceTestCase(unittest.TestCase):
     @print_test

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -311,20 +311,20 @@ class ContentExtractorTestCase(unittest.TestCase):
 
     def test_get_title_basic(self):
         html = '<title>Test title</title>'
-        assert self._get_title(html) == 'Test title'
+        self.assertEqual(self._get_title(html), 'Test title')
 
     def test_get_title_split(self):
         html = '<title>Test page » Test title</title>'
-        assert self._get_title(html) == 'Test title'
+        self.assertEqual(self._get_title(html), 'Test title')
 
     def test_get_title_split_escaped(self):
         html = '<title>Test page &raquo; Test title</title>'
-        assert self._get_title(html) == 'Test title'
+        self.assertEqual(self._get_title(html), 'Test title')
 
     def test_get_title_quotes(self):
         title = 'Test page and «something in quotes»'
         html = '<title>{}</title>'.format(title)
-        assert self._get_title(html) == title
+        self.assertEqual(self._get_title(html), title)
 
 
 class SourceTestCase(unittest.TestCase):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -321,6 +321,11 @@ class ContentExtractorTestCase(unittest.TestCase):
         html = '<title>Test page &raquo; Test title</title>'
         assert self._get_title(html) == 'Test title'
 
+    def test_get_title_quotes(self):
+        title = 'Test page and «something in quotes»'
+        html = '<title>{}</title>'.format(title)
+        assert self._get_title(html) == title
+
 
 class SourceTestCase(unittest.TestCase):
     @print_test


### PR DESCRIPTION
* Add some tests for title extraction - testing the extractor directly, in order not to add many heavy "fulltext" tests.
* Fix `TITLE_REPLACEMENTS` behavior which was removing both "&raquo;" and "»" instead of replacing the first with the second.
* Fix #73 by surrounding ARROW_SPLITTER with spaces. Usually when used as a splitter it will be preceded and followed by a space.