### PR TITLE
Fix unicode encoding errors in get_parsing_candidate

### DIFF
--- a/newspaper/utils.py
+++ b/newspaper/utils.py
@@ -47,8 +47,8 @@ class FileHelper(object):
 
 class ParsingCandidate(object):
 
-    def __init__(self, urlString, link_hash):
-        self.urlString = self.url = urlString
+    def __init__(self, url, link_hash):
+        self.url = url
         self.link_hash = link_hash
 
 

--- a/newspaper/utils.py
+++ b/newspaper/utils.py
@@ -56,7 +56,7 @@ class RawHelper(object):
     @staticmethod
     def get_parsing_candidate(url, raw_html):
         if isinstance(raw_html, str):
-            raw_html = raw_html.encode('utf-8')
+            raw_html = raw_html.encode('utf-8', 'replace')
         link_hash = '%s.%s' % (hashlib.md5(raw_html).hexdigest(), time.time())
         return ParsingCandidate(url, link_hash)
 


### PR DESCRIPTION
The encoding here is done for generating a hash of the content so ignoring a few incorrect unicode characters is better than throwing exceptions.

Fixes #211.