### PR TITLE
Remove six from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ cssselect>=0.9.1
 lxml>=3.3.5
 nltk>=3.0.1
 requests>=2.3.0
-six>=1.7.3
 feedparser>=5.1.3
 tldextract>=1.5.1
 feedfinder2>=0.0.4


### PR DESCRIPTION
It's obsolete now and isn't used anywhere.