### PR TITLE
Test with coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ python:
  - "3.4"
  - "3.5"
 install:
- - pip install -r requirements.txt coverage
+ - pip install -r requirements.txt coverage coveralls
  - python download_corpora.py
 script:
   - coverage run --source newspaper tests/unit_tests.py
-  - coverage report --show-missing --fail-under=50
+after_success:
+  coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
  - "3.4"
  - "3.5"
 install:
- - pip install -r requirements.txt
+ - pip install -r requirements.txt coverage
  - python download_corpora.py
 script:
-  - python tests/unit_tests.py
+  - coverage run --source newspaper tests/unit_tests.py
+  - coverage report --show-missing --fail-under=50

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ Newspaper3k: Article scraping & curation
         :target: http://travis-ci.org/codelucas/newspaper/
         :alt: Build status
 
+.. image:: https://coveralls.io/repos/github/codelucas/newspaper/badge.svg?branch=master
+        :target: https://coveralls.io/github/codelucas/newspaper
+        :alt: Coverage status
+
 
 Inspired by `requests`_ for its simplicity and powered by `lxml`_ for its speed:
 


### PR DESCRIPTION
* Run the tests on Travis with coverage
* Submit coverage report to coveralls
* Add coveralls coverage % badge to README.

I think this will be useful for evaluating tests for new features and improving the test suite overall.

@codelucas you can enable the coveralls builds here: https://coveralls.io/repos/new

The badge will look like this: [![Coverage Status](https://coveralls.io/repos/github/yprez/newspaper/badge.svg?branch=coverage)](https://coveralls.io/github/yprez/newspaper?branch=coverage)

There's also an option to leave coveralls out and show a text version of the coverage report in travis.