### PR TITLE
Fix caption

### DIFF
--- a/newspaper/cleaners.py
+++ b/newspaper/cleaners.py
@@ -53,6 +53,7 @@ class DocumentCleaner(object):
         doc_to_clean = self.clean_body_classes(doc_to_clean)
         doc_to_clean = self.clean_article_tags(doc_to_clean)
         doc_to_clean = self.clean_em_tags(doc_to_clean)
+        doc_to_clean = self.remove_embedded_cards(doc_to_clean)
         doc_to_clean = self.remove_drop_caps(doc_to_clean)
         doc_to_clean = self.remove_scripts_styles(doc_to_clean)
         doc_to_clean = self.clean_bad_tags(doc_to_clean)
@@ -128,6 +129,14 @@ class DocumentCleaner(object):
         naughty_names = self.parser.xpath_re(doc, self.nauthy_names_re)
         for node in naughty_names:
             self.parser.remove(node)
+        return doc
+
+    def remove_embedded_cards(self, doc):
+        list= ["twitter-tweet", "instagram-media"]
+        for value in list:
+            elements = self.parser.getElementsByAttr(doc, 'class', value)
+            for element in elements:
+                self.parser.drop_tree(element)
         return doc
 
     def remove_nodes_regex(self, doc, pattern):

--- a/newspaper/cleaners.py
+++ b/newspaper/cleaners.py
@@ -54,6 +54,7 @@ class DocumentCleaner(object):
         doc_to_clean = self.clean_article_tags(doc_to_clean)
         doc_to_clean = self.clean_em_tags(doc_to_clean)
         doc_to_clean = self.remove_embedded_cards(doc_to_clean)
+        doc_to_clean = self.remove_caption(doc_to_clean)
         doc_to_clean = self.remove_drop_caps(doc_to_clean)
         doc_to_clean = self.remove_scripts_styles(doc_to_clean)
         doc_to_clean = self.clean_bad_tags(doc_to_clean)
@@ -93,6 +94,17 @@ class DocumentCleaner(object):
                 self.parser.drop_tag(node)
         return doc
 
+    def remove_caption(self, doc):
+        figcaptions = self.parser.getElementsByTag(doc, tag='figcaption')
+        for node in figcaptions:
+            self.parser.drop_tree(node)
+        list=['img_cptn' , 'story_top_news_text' , 'caption']
+        for value in list:
+            elements = self.parser.getElementsByAttr(doc, 'class', value)
+            for element in elements:
+                self.parser.drop_tree(element)
+        return doc
+
     def remove_drop_caps(self, doc):
         items = self.parser.css_select(doc, 'span[class~=dropcap], '
                                        'span[class~=drop_cap]')
@@ -114,7 +126,7 @@ class DocumentCleaner(object):
         for item in comments:
             self.parser.remove(item)
 
-        return doc
+        return doc_to_clean
 
     def clean_bad_tags(self, doc):
         # ids

--- a/newspaper/parsers.py
+++ b/newspaper/parsers.py
@@ -39,6 +39,14 @@ class Parser(object):
             nodes.drop_tag()
 
     @classmethod
+    def drop_tree(cls, nodes):
+        if isinstance(nodes, list):
+            for node in nodes:
+                node.drop_tree()
+        else:
+            nodes.drop_tree()
+
+    @classmethod
     def css_select(cls, node, selector):
         return node.cssselect(selector)
 
@@ -98,6 +106,13 @@ class Parser(object):
     @classmethod
     def stripTags(cls, node, *tags):
         lxml.etree.strip_tags(node, *tags)
+
+    @classmethod
+    def getElementsByAttr(cls, node, attr, value):
+        NS = "http://exslt.org/regular-expressions"
+        selector = '//*[re:test(@%s, "%s", "i")]' % (attr, value)
+        elems = node.xpath(selector, namespaces={"re": NS})
+        return elems
 
     @classmethod
     def getElementById(cls, node, idd):


### PR DESCRIPTION
The original caption removal code does not remove a lot of image captions which ultimately become a part of the article text and mess it up. Have added a fix to do the same.