### PR TITLE
Add `html` kwarg for loading article content

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -33,7 +33,7 @@ class ArticleException(Exception):
 class Article(object):
     """Article objects abstract an online news article page
     """
-    def __init__(self, url, title='', source_url='', config=None, **kwargs):
+    def __init__(self, url, html='', title='', source_url='', config=None, **kwargs):
         """The **kwargs argument may be filled with config values, which
         is added into the config object
         """
@@ -89,6 +89,8 @@ class Article(object):
 
         # This article's unchanged and raw HTML
         self.html = ''
+        if html:
+            self.set_html(html)
 
         # The HTML of this article's main node (most important part)
         self.article_html = ''
@@ -96,7 +98,11 @@ class Article(object):
         # Flags warning users in-case they forget to download() or parse()
         # or if they call methods out of order
         self.is_parsed = False
+
         self.is_downloaded = False
+        if self.html:
+            # User has loaded html content, does not require download restriction
+            self.is_downloaded = True
 
         # Meta description field in the HTML source
         self.meta_description = ""

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -210,6 +210,15 @@ class ArticleTestCase(unittest.TestCase):
         self.assertRaises(ArticleException, article.parse)
 
     @print_test
+    def test_no_download_but_html_kwarg_parse(self):
+        """Calling `parse()` after passing `html` kwarg should work
+        """
+        html = 'foo.bar'
+        article = Article('http://foo.bar', html=html)
+        article.parse()
+        self.assertEqual(article.html, html)
+
+    @print_test
     def test_parse_html(self):
         self.setup_stage('parse')
 


### PR DESCRIPTION
My personal experience, #74, #161 and #37 bring me to believe this is necessary.

As it stands right now, I don't understand why you force the user to `download()`.

It's a confusing API (using `set_html`) for people who just want the parse functionality.