### PR TITLE
Fix relative canonical link (See #228)

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -515,20 +515,18 @@ class ContentExtractor(object):
         result = ''
 
         links = self.parser.getElementsByTag(doc, tag='link', attr='rel', value='canonical')
-        canonical = self.parser.getAttribute(links[0], 'href') if links else ''
 
+        canonical = self.parser.getAttribute(links[0], 'href') if links else ''
         og_url = self.get_meta_content(doc, 'meta[property="og:url"]')
 
-        if canonical:
-            canonical = canonical.strip()
-            o = urllib.parse.urlparse(canonical)
+        result = canonical or og_url or ''
+        if result:
+            result = result.strip()
+            o = urllib.parse.urlparse(result)
             if not o.hostname:
                 z = urllib.parse.urlparse(article_url)
                 domain = '%s://%s' % (z.scheme, z.hostname)
-                canonical = urllib.parse.urljoin(domain, canonical)
-            result = canonical
-        elif og_url:
-            result = og_url  # fallback to og:url tag, must be the full url
+                result = urllib.parse.urljoin(domain, result)
 
         return result
 

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -512,23 +512,24 @@ class ContentExtractor(object):
         2. The og:url tag
         """
 
-        result = ''
+        url = ''
 
         links = self.parser.getElementsByTag(doc, tag='link', attr='rel', value='canonical')
 
         canonical = self.parser.getAttribute(links[0], 'href') if links else ''
         og_url = self.get_meta_content(doc, 'meta[property="og:url"]')
 
-        result = canonical or og_url or ''
-        if result:
-            result = result.strip()
-            o = urllib.parse.urlparse(result)
-            if not o.hostname:
-                z = urllib.parse.urlparse(article_url)
-                domain = '%s://%s' % (z.scheme, z.hostname)
-                result = urllib.parse.urljoin(domain, result)
+        url = canonical or og_url or ''
+        if url:
+            url = url.strip()
+            parsed_url = urllib.parse.urlparse(url)
+            if not parsed_url.hostname:
+                parsed_article_url = urllib.parse.urlparse(article_url)
+                domain = '{}://{}'.format(parsed_article_url.scheme,
+                                          parsed_article_url.hostname)
+                url = urllib.parse.urljoin(domain, url)
 
-        return result
+        return url
 
     def get_img_urls(self, article_url, doc):
         """Return all of the images on an html page, lxml root

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -13,7 +13,7 @@ import concurrent.futures
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 PARENT_DIR = os.path.join(TEST_DIR, '..')
 
-# newspaper's unit tests are in their own seperate module, so
+# newspaper's unit tests are in their own separate module, so
 # insert the parent directory manually to gain scope of the
 # core module
 sys.path.insert(0, PARENT_DIR)
@@ -325,27 +325,32 @@ class ContentExtractorTestCase(unittest.TestCase):
         html = '<title>{}</title>'.format(title)
         self.assertEqual(self._get_title(html), title)
 
-    def _get_canonical_link(self, html, article_url=''):
+    def _get_canonical_link(self, article_url, html):
         doc = self.parser.fromstring(html)
         return self.extractor.get_canonical_link(article_url, doc)
 
     def test_get_canonical_link_rel_canonical(self):
         url = 'http://www.example.com/article.html'
         html = '<link rel="canonical" href="{}">'.format(url)
-        self.assertEqual(self._get_canonical_link(html), url)
+        self.assertEqual(self._get_canonical_link('', html), url)
 
     def test_get_canonical_link_rel_canonical_absolute_url(self):
         url = 'http://www.example.com/article.html'
         html = '<link rel="canonical" href="article.html">'
         article_url = 'http://www.example.com/article?foo=bar'
-        self.assertEqual(self._get_canonical_link(html, article_url), url)
+        self.assertEqual(self._get_canonical_link(article_url, html), url)
 
     def test_get_canonical_link_og_url_absolute_url(self):
         url = 'http://www.example.com/article.html'
         html = '<meta property="og:url" content="article.html">'
         article_url = 'http://www.example.com/article?foo=bar'
-        self.assertEqual(self._get_canonical_link(html, article_url), url)
+        self.assertEqual(self._get_canonical_link(article_url, html), url)
 
+    def test_get_canonical_link_hostname_og_url_absolute_url(self):
+        url = 'http://www.example.com/article.html'
+        html = '<meta property="og:url" content="www.example.com/article.html">'
+        article_url = 'http://www.example.com/article?foo=bar'
+        self.assertEqual(self._get_canonical_link(article_url, html), url)
 
 class SourceTestCase(unittest.TestCase):
     @print_test

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -325,6 +325,27 @@ class ContentExtractorTestCase(unittest.TestCase):
         html = '<title>{}</title>'.format(title)
         self.assertEqual(self._get_title(html), title)
 
+    def _get_canonical_link(self, html, article_url=''):
+        doc = self.parser.fromstring(html)
+        return self.extractor.get_canonical_link(article_url, doc)
+
+    def test_get_canonical_link_rel_canonical(self):
+        url = 'http://www.example.com/article.html'
+        html = '<link rel="canonical" href="{}">'.format(url)
+        self.assertEqual(self._get_canonical_link(html), url)
+
+    def test_get_canonical_link_rel_canonical_absolute_url(self):
+        url = 'http://www.example.com/article.html'
+        html = '<link rel="canonical" href="article.html">'
+        article_url = 'http://www.example.com/article?foo=bar'
+        self.assertEqual(self._get_canonical_link(html, article_url), url)
+
+    def test_get_canonical_link_og_url_absolute_url(self):
+        url = 'http://www.example.com/article.html'
+        html = '<meta property="og:url" content="article.html">'
+        article_url = 'http://www.example.com/article?foo=bar'
+        self.assertEqual(self._get_canonical_link(html, article_url), url)
+
 
 class SourceTestCase(unittest.TestCase):
     @print_test


### PR DESCRIPTION
PR #228 looks good but it wasn't handling a meta url like 'example.com/article.html', only urls like 'article.html' would have been parsed correctly.

I added a new test and refactored `get_canonical_link()` accordingly
