### PR TITLE
Changes in Readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,6 +241,8 @@ package name is ``newspaper``.
 
     $ sudo apt-get install libjpeg-dev zlib1g-dev libpng12-dev
 
+NOTE: If you find problem installing ``libpng12-dev``, try installing ``libpng-dev``.
+
 - Install the distribution via pip::
 
     $ pip3 install newspaper3k


### PR DESCRIPTION
I was facing problem while install "libpng12-dev", so I tried installing "libpng-dev" instead, which worked fine. So I added a little note in the Readme file.
 
![screenshot from 2016-12-28 20-29-42](https://cloud.githubusercontent.com/assets/11015077/21524481/62ae5f8e-cd3c-11e6-803d-08a7c090a4f3.png)
