### PR TITLE
Create reference to article_html node

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -125,6 +125,9 @@ class Article(object):
         # "most important part of the page"
         self.clean_top_node = None
 
+        # lxml DOM object is used to generate article_html
+        self.top_node_article_html = None
+
         # lxml DOM object generated from HTML
         self.doc = None
 
@@ -235,6 +238,7 @@ class Article(object):
                 self.top_node)
             self.set_article_html(article_html)
             self.set_text(text)
+            self.top_node_article_html = output_formatter.get_top_node_article_html()
 
         if self.config.fetch_images:
             self.fetch_images()

--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -20,6 +20,7 @@ class OutputFormatter(object):
 
     def __init__(self, config):
         self.top_node = None
+        self.top_node_article_html = None
         self.config = config
         self.parser = self.config.get_parser()
         self.language = config.language
@@ -37,6 +38,9 @@ class OutputFormatter(object):
 
     def get_top_node(self):
         return self.top_node
+
+    def get_top_node_article_html(self):
+        return self.top_node_article_html
 
     def get_formatted(self, top_node):
         """Returns the body text of an article, and also the body article
@@ -77,8 +81,8 @@ class OutputFormatter(object):
         return '\n\n'.join(txts)
 
     def convert_to_html(self):
-        cleaned_node = self.parser.clean_article_html(self.get_top_node())
-        return self.parser.nodeToString(cleaned_node)
+        self.top_node_article_html = self.parser.clean_article_html(self.get_top_node())
+        return self.parser.nodeToString(self.top_node_article_html)
 
     def add_newline_to_br(self):
         for e in self.parser.getElementsByTag(self.top_node, tag='br'):


### PR DESCRIPTION
There is no any relevant reference to lxml node, which converts to article_html.
But it is very useful if you want to modify DOM tree before converting it to html string.