### PR TITLE
Exclude .pyc files from packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include requirements.txt README.rst LICENSErecursive-include newspaper *
+include requirements.txt README.rst LICENSErecursive-include newspaper *recursive-exclude * __pycache__recursive-exclude * *.py[co]


### PR DESCRIPTION
This should fix #350.

Currently `setup.py sdist` includes all *.pyc, *.pyo files and `__pycache__` directories in the generated package.

Running `python setup.py sdist` before this change:

```
running sdist
running egg_info
...
hard linking newspaper/__init__.py -> newspaper3k-0.1.9/newspaper
hard linking newspaper/__init__.pyc -> newspaper3k-0.1.9/newspaper
hard linking newspaper/api.py -> newspaper3k-0.1.9/newspaper
hard linking newspaper/api.pyc -> newspaper3k-0.1.9/newspaper
hard linking newspaper/article.py -> newspaper3k-0.1.9/newspaper
hard linking newspaper/article.pyc -> newspaper3k-0.1.9/newspaper
hard linking newspaper/cleaners.py -> newspaper3k-0.1.9/newspaper
hard linking newspaper/cleaners.pyc -> newspaper3k-0.1.9/newspaper
...
```