### PR TITLE
Use Temp Dir instead of Home Dir

### DIFF
--- a/newspaper/settings.py
+++ b/newspaper/settings.py
@@ -10,6 +10,7 @@ __copyright__ = 'Copyright 2014, Lucas Ou-Yang'
 
 import logging
 import os
+import tempfile
 
 from http.cookiejar import CookieJar as cj
 
@@ -31,7 +32,7 @@ NLP_STOPWORDS_EN = os.path.join(
 
 DATA_DIRECTORY = '.newspaper_scraper'
 
-TOP_DIRECTORY = os.path.join(os.path.expanduser("~"), DATA_DIRECTORY)
+TOP_DIRECTORY = os.path.join(tempfile.gettempdir(), DATA_DIRECTORY)
 if not os.path.exists(TOP_DIRECTORY):
     os.mkdir(TOP_DIRECTORY)
 


### PR DESCRIPTION
Using home directories is bad practice for certain deployment strategies (Elastic Beanstalk, Heroku etc), and limits the OS-scope of the project. Rather use a Temp Directory, which is more secure and doesn't require extra permissions (for a server role eg. Elastic Beanstalk)