### PR TITLE
NLTK Corpus dependency install before newspaper3k

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -243,14 +243,13 @@ package name is ``newspaper``.
 
 NOTE: If you find problem installing ``libpng12-dev``, try installing ``libpng-dev``.
 
-- Install the distribution via pip::
-
-    $ pip3 install newspaper3k
-
 - Download NLP related corpora::
 
     $ curl https://raw.githubusercontent.com/codelucas/newspaper/master/download_corpora.py | python3
 
+- Install the distribution via pip::
+
+    $ pip3 install newspaper3k
 
 **If you are on OSX**, install using the following, you may use both homebrew or macports:
 


### PR DESCRIPTION
The corpora is required for the install or newspaper3k or else it errors.
I tried pip installing, cloning & downloading older versions of newspaper3k before realising.

While the change seems minor it may prevent users from being deterred because they couldn't get the library working, thought it would be a good idea :-)