### PR TITLE
Add logic to handle http != 2XX response failures. Inform user download happened

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -398,19 +398,19 @@ class Article(object):
             self.set_top_img(s.largest_image_url())
         except TypeError as e:
             if "Can't convert 'NoneType' object to str implicitly" in e.args[0]:
-                log.debug("No pictures found. Top image not set, %s" % e)
-            elif "timed out" in e.args[0]:
-                log.debug("Download of picture timed out. Top image not set, %s" % e)
+                log.debug('No pictures found. Top image not set, %s' % e)
+            elif 'timed out' in e.args[0]:
+                log.debug('Download of picture timed out. Top image not set, %s' % e)
             else:
-                log.critical('TypeError other than None type error. Cannot set top image using the Reddit algorithm. Possible error with PIL., %s' % e)
+                log.critical('TypeError other than None type error. '
+                             'Cannot set top image using the Reddit '
+                             'algorithm. Possible error with PIL., %s' % e)
         except Exception as e:
-            log.critical('Other error with setting top image using the Reddit algorithm. Possible error with PIL, %s' % e)
+            log.critical('Other error with setting top image using the '
+                         'Reddit algorithm. Possible error with PIL, %s' % e)
 
     def set_title(self, input_title):
         if input_title:
-            if self.title:
-                # Title has already been set by an educated guess
-                return
             self.title = input_title[:self.config.MAX_TITLE]
 
     def set_text(self, text):

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -18,6 +18,8 @@ from .settings import cj
 log = logging.getLogger(__name__)
 
 
+FAIL_ENCODING = 'ISO-8859-1'
+
 def get_request_kwargs(timeout, useragent):
     """This Wrapper method exists b/c some values in req_kwargs dict
     are methods which need to be called every time we make a request
@@ -31,44 +33,47 @@ def get_request_kwargs(timeout, useragent):
 
 
 def get_html(url, config=None, response=None):
-    """Retrieves the html for either a url or a response object. All html
-    extractions MUST come from this method due to some intricies in the
-    requests module. To get the encoding, requests only uses the HTTP header
-    encoding declaration requests.utils.get_encoding_from_headers() and reverts
-    to ISO-8859-1 if it doesn't find one. This results in incorrect character
-    encoding in a lot of cases.
+    try:
+        return get_html_2XX_only(url, config, response)
+    except requests.exceptions.RequestException as e:
+        log.debug('%s on %s' % (e, url))
+        return ''
+
+
+def get_html_2XX_only(url, config=None, response=None):
     """
-    FAIL_ENCODING = 'ISO-8859-1'
+    Consolidated logic for http requests from newspaper. We handle error cases:
+    - Attempt to find encoding of the html by using HTTP header. Fallback to 
+      'ISO-8859-1' if not provided.
+    - Error out if a non 2XX HTTP response code is returned.
+    """
     config = config or Configuration()
     useragent = config.browser_user_agent
     timeout = config.request_timeout
 
     if response is not None:
-        if response.encoding != FAIL_ENCODING:
-            return response.text
-        return response.content
+        return _get_html_from_response(response)
 
-    try:
-        html = None
+    response = requests.get(
+        url=url, **get_request_kwargs(timeout, useragent))
 
-        response = requests.get(
-            url=url, **get_request_kwargs(timeout, useragent))
+    html = _get_html_from_response(response)
 
-        if response.encoding != FAIL_ENCODING:
-            html = response.text
-        else:
-            html = response.content
+    if config.http_success_only:
+        # fail if HTTP sends a non 2XX response
+        response.raise_for_status()
 
-        if config.http_success_only:
-            response.raise_for_status()  # fail if other than "ok" response
+    return html
 
-        if html is None:
-            html = ''
 
-        return html
-    except requests.exceptions.RequestException as e:
-        log.debug('%s on %s' % (e, url))
-        return ''
+def _get_html_from_response(response):
+    if response.encoding != FAIL_ENCODING:
+        # return response as a unicode string
+        html = response.text
+    else:
+        # don't attempt decode, return response in bytes
+        html = response.content
+    return html or ''
 
 
 class MRequest(object):

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -33,16 +33,17 @@ def get_request_kwargs(timeout, useragent):
 
 
 def get_html(url, config=None, response=None):
+    """HTTP response code agnostic 
+    """
     try:
         return get_html_2XX_only(url, config, response)
     except requests.exceptions.RequestException as e:
-        log.debug('%s on %s' % (e, url))
+        log.debug('get_html() error. %s on URL: %s' % (e, url))
         return ''
 
 
 def get_html_2XX_only(url, config=None, response=None):
-    """
-    Consolidated logic for http requests from newspaper. We handle error cases:
+    """Consolidated logic for http requests from newspaper. We handle error cases:
     - Attempt to find encoding of the html by using HTTP header. Fallback to 
       'ISO-8859-1' if not provided.
     - Error out if a non 2XX HTTP response code is returned.
@@ -54,8 +55,12 @@ def get_html_2XX_only(url, config=None, response=None):
     if response is not None:
         return _get_html_from_response(response)
 
-    response = requests.get(
-        url=url, **get_request_kwargs(timeout, useragent))
+    try:
+        response = requests.get(
+            url=url, **get_request_kwargs(timeout, useragent))
+    except requests.exceptions.RequestException as e:
+        log.debug('get_html_2XX_only() error. %s on URL: %s' % (e, url))
+        return ''
 
     html = _get_html_from_response(response)
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -187,7 +187,7 @@ class ArticleTestCase(unittest.TestCase):
         article = Article(
             '', config=config)
         html = mock_resource_with('google_meta_refresh', 'html')
-        article.download(html=html)
+        article.download(input_html=html)
         article.parse()
         self.assertEqual(article.title, 'Example Domain')
 
@@ -198,7 +198,7 @@ class ArticleTestCase(unittest.TestCase):
         article = Article(
             '', config=config)
         html = mock_resource_with('ap_meta_refresh', 'html')
-        article.download(html=html)
+        article.download(input_html=html)
         article.parse()
         self.assertEqual(article.title, 'News from The Associated Press')
 


### PR DESCRIPTION
This is a much needed feature due to a lot of issues being created where people are calling `download()` on their article objects but fail to `parse()` the article contents from the HTML due to bad API design not distinguishing good http responses and bad http responses.

This PR makes it clear when an http response to some news website fails - whether by rate limiting, broken website server, etc. Now our api users will be more clear of what is going on.

Waiting for current integration/unit tests to pass and thinking about adding more

cc https://github.com/codelucas/newspaper/issues/357