### PR TITLE
change content tag name for datePublished

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -203,7 +203,7 @@ class ContentExtractor(object):
             {'attribute': 'name', 'value': 'OriginalPublicationDate',
              'content': 'content'},
             {'attribute': 'itemprop', 'value': 'datePublished',
-             'content': 'datetime'},
+             'content': 'content'},
             {'attribute': 'property', 'value': 'og:published_time',
              'content': 'content'},
             {'attribute': 'name', 'value': 'article_date_original',


### PR DESCRIPTION
To be inline with http://schema.org/datePublished

Test page [here](https://zap.aeiou.pt/drones-so-vao-poder-voar-ate-120-metros-longe-dos-aeroportos-141571).