### PR TITLE
Fix article URL generation

### DIFF
--- a/newspaper/source.py
+++ b/newspaper/source.py
@@ -261,7 +261,7 @@ class Source(object):
             for url in urls:
                 article = Article(
                     url=url,
-                    source_url=self.url,
+                    source_url=feed.url,
                     config=self.config)
                 cur_articles.append(article)
 
@@ -297,7 +297,7 @@ class Source(object):
 
                 _article = Article(
                     url=indiv_url,
-                    source_url=self.url,
+                    source_url=category.url,
                     title=indiv_title,
                     config=self.config
                 )


### PR DESCRIPTION
Homepage URL as ```source_url``` in article creation will cause ```prepare_url``` to render a wrong URL in some scenarios. For example:

* Homepage: ```http://example.com/```
* Category: ```http://example.com/cat/```
* ```a href``` in the category page: ```./123/```
* Real Article URL (expected): ```http://example.com/cat/123/```
* URL detected: ```http://example.com/123/``` (by combining ```http://example.com/``` and ```./123/```)