### PR TITLE
Speed up getElementsByTags

### DIFF
--- a/newspaper/parsers.py
+++ b/newspaper/parsers.py
@@ -162,12 +162,9 @@ class Parser(object):
 
     @classmethod
     def getElementsByTags(cls, node, tags):
-        selector = ','.join(tags)
-        elems = cls.css_select(node, selector)
-        # remove the root node
-        # if we have a selection tag
-        if node in elems:
-            elems.remove(node)
+        selector = 'descendant::*[%s]' * (
+            ' or '.join(self::%s' % tag for tag in tags))
+        elems = node.xpath(selector)
         return elems
 
     @classmethod

--- a/newspaper/parsers.py
+++ b/newspaper/parsers.py
@@ -162,8 +162,8 @@ class Parser(object):
 
     @classmethod
     def getElementsByTags(cls, node, tags):
-        selector = 'descendant::*[%s]' * (
-            ' or '.join(self::%s' % tag for tag in tags))
+        selector = 'descendant::*[%s]' % (
+            ' or '.join('self::%s' % tag for tag in tags))
         elems = node.xpath(selector)
         return elems
 


### PR DESCRIPTION
The `css_select` method internally converts the css selector string into an xpath selector string and then calls xpath. It is quite a lot faster to simply use an xpath selector. In profiling, this change reduces `getElementsByTags` from ~ 25% of `article.parse` execution time to less than 10%.
This PR should not change functionality.