### PR TITLE
Better get_meta_lang

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -410,9 +410,9 @@ class ContentExtractor(object):
         if attr is None:
             # look up for a Content-Language in meta
             items = [
-                {'tag': 'meta', 'attr': 'http-equiv',
-                 'value': 'content-language'},
-                {'tag': 'meta', 'attr': 'name', 'value': 'lang'}
+                {'tag': 'meta', 'attr': 'http-equiv', 'value': 'content-language'},
+                {'tag': 'meta', 'attr': 'name', 'value': 'lang'},
+				{'tag': 'meta', 'attr': 'property', 'value': 'og:locale'}
             ]
             for item in items:
                 meta = self.parser.getElementsByTag(doc, **item)


### PR DESCRIPTION
Added one more case in the language detection.
To solve a problem with the following page: http://quebec.huffingtonpost.ca/2017/09/04/trump-evoque-la-vente-a-seoul-de-milliards-de-dollars-de-materiel-militaire_a_23196569/
