### PR TITLE
Fix attribute loss for div elements after running document cleaner

### DIFF
--- a/newspaper/cleaners.py
+++ b/newspaper/cleaners.py
@@ -3,6 +3,7 @@
 Holds the code for cleaning out unwanted tags from the lxml
 dom xpath.
 """
+import copy
 from .utils import ReplaceSequence
 
 
@@ -226,8 +227,11 @@ class DocumentCleaner(object):
             elif div is not None:
                 replace_nodes = self.get_replacement_nodes(doc, div)
                 replace_nodes = [n for n in replace_nodes if n is not None]
+                attrib = copy.deepcopy(div.attrib)
                 div.clear()
                 for i, node in enumerate(replace_nodes):
                     div.insert(i, node)
+                for name, value in attrib.items():
+                    div.set(name, value)
                 else_divs += 1
         return doc


### PR DESCRIPTION
```div_to_para()``` uses ```doc.clear()``` to remove children nodes. However, while doing so it also removes attributes including id and class:

> Resets an element. This function removes all subelements, clears all attributes and sets the text and tail properties to None.

This PR backup the attributes and restore them after ```doc.clear()```.