### PR TITLE
Allow to define extra headers on the configuration object

### DIFF
--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -64,6 +64,7 @@ class Configuration(object):
         self.stopwords_class = StopWords
 
         self.browser_user_agent = 'newspaper/%s' % __version__
+        self.headers = {}
         self.request_timeout = 7
         self.proxies = {}
         self.number_threads = 10

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -20,12 +20,13 @@ log = logging.getLogger(__name__)
 
 FAIL_ENCODING = 'ISO-8859-1'
 
-def get_request_kwargs(timeout, useragent, proxies):
+
+def get_request_kwargs(timeout, useragent, proxies, headers):
     """This Wrapper method exists b/c some values in req_kwargs dict
     are methods which need to be called every time we make a request
     """
     return {
-        'headers': {'User-Agent': useragent},
+        'headers': headers if headers else {'User-Agent': useragent},
         'cookies': cj(),
         'timeout': timeout,
         'allow_redirects': True,
@@ -53,13 +54,14 @@ def get_html_2XX_only(url, config=None, response=None):
     useragent = config.browser_user_agent
     timeout = config.request_timeout
     proxies = config.proxies
+    headers = config.headers
 
     if response is not None:
         return _get_html_from_response(response)
 
     try:
         response = requests.get(
-            url=url, **get_request_kwargs(timeout, useragent, proxies))
+            url=url, **get_request_kwargs(timeout, useragent, proxies, headers))
     except requests.exceptions.RequestException as e:
         log.debug('get_html_2XX_only() error. %s on URL: %s' % (e, url))
         return ''


### PR DESCRIPTION
If a dictionary with the headers is defined it will be used when doing requests.