### PR TITLE
Fix bug introduced in meta-image fix PR #324

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -450,7 +450,7 @@ class ContentExtractor(object):
         if not try_one:
             link_img_src_kwargs = \
                 {'tag': 'link', 'attr': 'rel', 'value': 'img_src|image_src'}
-            elems = self.parser.getElementsByTag(doc, **link_img_src_kwargs)
+            elems = self.parser.getElementsByTag(doc, use_regex=True, **link_img_src_kwargs)
             try_two = elems[0].get('href') if elems else None
 
             if not try_two:


### PR DESCRIPTION
PR #324 by @mercuree fixes a lot of our meta image functionality but incidentally also collides with mercuree's earlier optimization of speeding up `getElementsByTag` by turning off regex search.

I have added the regex option back **only for this particular meta_img call** so that the meta img is fetched with the regex as expected - but all others calls have regex=False as expected.

Unit tests passed, yielding:
```
~VIRTUAL_ENV/newspaper(branch:fix-bug-with-regex-dom-query*) » python3 tests/unit_tests.py                                    codelucas@lucas-macbook
	testing function 'test_hot_trending'
	[OK] in 'test_hot_trending' 0.28 sec
	testing function 'test_popular_urls'
	[OK] in 'test_popular_urls' 0.00 sec
	testing function 'test_download_html'
	[OK] in 'test_download_html' 0.00 sec
	testing function 'test_meta_extraction'
	[OK] in 'test_meta_extraction' 0.31 sec
	testing function 'test_meta_refresh_no_url_redirect'
	[OK] in 'test_meta_refresh_no_url_redirect' 0.19 sec
	testing function 'test_meta_refresh_redirect'
	[OK] in 'test_meta_refresh_redirect' 0.06 sec
	testing function 'test_meta_type_extraction'
	[OK] in 'test_meta_type_extraction' 0.27 sec
	testing function 'test_nlp_body'
	[OK] in 'test_nlp_body' 0.49 sec
	testing function 'test_parse_html'
	[OK] in 'test_parse_html' 0.45 sec
	testing function 'test_pre_download_nlp'
You must `download()` an article first!
	[OK] in 'test_pre_download_nlp' 0.00 sec
	testing function 'test_pre_download_parse'
You must `download()` an article first!
	[OK] in 'test_pre_download_parse' 0.00 sec
	testing function 'test_pre_parse_nlp'
You must `parse()` an article first!
	[OK] in 'test_pre_parse_nlp' 0.00 sec
	testing function 'test_url'
	[OK] in 'test_url' 0.00 sec
	testing function 'test_article_custom_params'
	[OK] in 'test_article_custom_params' 0.00 sec
	testing function 'test_article_default_params'
	[OK] in 'test_article_default_params' 0.00 sec
	testing function 'test_source_custom_params'
	[OK] in 'test_source_custom_params' 0.00 sec
	testing function 'test_source_default_params'
	[OK] in 'test_source_default_params' 0.00 sec
	testing function 'test_arabic_fulltext_extract'
	[OK] in 'test_arabic_fulltext_extract' 0.40 sec
	testing function 'test_chinese_fulltext_extract'
Building prefix dict from /Users/codelucas/newspaper-env/lib/python3.5/site-packages/jieba/dict.txt ...
Loading model from cache /var/folders/kx/gfslqkjs4mb5mf8nxzrjnzrm0000gn/T/jieba.cache
Loading model cost 1.4848310947418213 seconds.
Prefix dict has been built succesfully.
	[OK] in 'test_chinese_fulltext_extract' 1.86 sec
	testing function 'test_spanish_fulltext_extract'
	[OK] in 'test_spanish_fulltext_extract' 0.56 sec
	testing function 'test_source_url_input_none'
	[OK] in 'test_source_url_input_none' 0.00 sec
	testing function 'test_prepare_url'
	[OK] in 'test_prepare_url' 0.00 sec
	testing function 'test_valid_urls'
	[OK] in 'test_valid_urls' 0.00 sec
----------------------------------------------------------------------
Ran 36 tests in 4.906s

OK (skipped=4)
```