### PR TITLE
Update nltk version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
-include requirements.txt README.rst LICENSErecursive-include newspaper *recursive-exclude * __pycache__recursive-exclude * *.py[co]
+include requirements.txt README.rst LICENSE
+recursive-include newspaper *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Pillow==2.5.1
 PyYAML==3.11
 cssselect==0.9.1
 lxml==3.3.5
-nltk==2.0.5
+nltk==3.2.5
 requests==2.6.0
 six==1.7.3
 jieba==0.35

--- a/tests/data/text/cnn_summary.txt
+++ b/tests/data/text/cnn_summary.txt
@@ -1,5 +1,5 @@
 Forecasters see mostly smooth sailing into Thanksgiving.
 The forecast has left up in the air the fate of the balloons in Macy's Thanksgiving Day Parade.
-"That's good news for people like Latasha Abney, who joined the more than 43 million Americans expected by AAA to travel over the Thanksgiving holiday weekend.
+That's good news for people like Latasha Abney, who joined the more than 43 million Americans expected by AAA to travel over the Thanksgiving holiday weekend.
 Though the worst of the storm has passed, winds could still pose a problem.
 The storm caused some complications and inconveniences, but no major delays or breakdowns.


### PR DESCRIPTION
nltk 2.0.5 [doesn't seem to install](https://stackoverflow.com/questions/46977498/urllib2-httperror-http-error-403-ssl-is-required-when-installing-nltk-2-0-5). How about we update to a version that works?

Tests pass with these changes:

```
$ python tests/unit_tests.py
        testing function 'test_config_build'
        [OK] in 'test_config_build' 0.01 sec
.       testing function 'test_chinese_fulltext_extract'
Building prefix dict from <OBSCURED>/lib/python2.7/site-packages/jieba/dict.txt ...
Loading model from cache /var/folders/mt/4fq_3q8s6hzg69gy03lq40zm0000gn/T/jieba.cache
Loading model cost 0.455691099167 seconds.
Prefix dict has been built succesfully.
        [OK] in 'test_chinese_fulltext_extract' 0.93 sec
        testing function 'test_arabic_fulltext_extract'
        [OK] in 'test_arabic_fulltext_extract' 0.32 sec
        testing function 'test_spanish_fulltext_extract'
        [OK] in 'test_spanish_fulltext_extract' 41.24 sec
.       testing function 'test_valid_urls'
        [OK] in 'test_valid_urls' 0.00 sec
.       testing function 'test_url'
        [OK] in 'test_url' 0.00 sec
        testing function 'test_download_html'
        [OK] in 'test_download_html' 0.00 sec
        testing function 'test_pre_download_parse'
You must download() an article before parsing it!
        [OK] in 'test_pre_download_parse' 0.00 sec
        testing function 'test_parse_html'
        [OK] in 'test_parse_html' 0.31 sec
        testing function 'test_meta_type_extraction'
        [OK] in 'test_meta_type_extraction' 0.00 sec
        testing function 'test_meta_extraction'
        [OK] in 'test_meta_extraction' 0.00 sec
        testing function 'test_pre_download_nlp'
You must download and parse an article before parsing it!
        [OK] in 'test_pre_download_nlp' 0.00 sec
        testing function 'test_pre_parse_nlp'
You must download and parse an article before parsing it!
        [OK] in 'test_pre_parse_nlp' 0.00 sec
        testing function 'test_nlp_body'
        [OK] in 'test_nlp_body' 0.00 sec
.       testing function 'test_hot_trending'
        [OK] in 'test_hot_trending' 0.31 sec
        testing function 'test_popular_urls'
        [OK] in 'test_popular_urls' 0.00 sec
.
----------------------------------------------------------------------
Ran 5 tests in 43.129s

OK
```