### PR TITLE
Added reference corpus keyword functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 Newspaper3k: Article scraping & curation
 ========================================
 
+🚩 This **fork** introduces the capability of generating keywords based on a (log-likelihood) comparison with a reference corpus such as the *Contemporary Corpus of American English* or the *British National Corpus*.
+
 .. image:: https://badge.fury.io/py/newspaper3k.svg
     :target: http://badge.fury.io/py/newspaper3k.svg
         :alt: Latest version

--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -221,6 +221,15 @@ before calling ``nlp()``.
     Traceback (...
     ArticleException: You must parse an article before you try to..
 
+You can define an external text file as a reference corpus for keyword detection (via. log-likelihood).
+
+.. code-block:: pycon
+
+    >>> first_article.nlp(reference_corpus='reference.txt')
+
+    >>> print(first_article.keywords_reference_corpus)
+    [u'music', u'Tucson', ... ]
+
 
 ``nlp()`` is expensive, as is ``parse()``, make sure you actually need them before calling them on
 all of your articles! In some cases, if you just need urls, even ``download()`` is not necessary.

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -84,6 +84,9 @@ class Article(object):
         # `keywords` are extracted via nlp() from the body text
         self.keywords = []
 
+        # `keywords_reference_corpus` are extracted via nlp() from the body text
+        self.keywords_reference_corpus = ['No reference corpus defined']
+
         # `meta_keywords` are extracted via parse() from <meta> tags
         self.meta_keywords = []
 
@@ -336,7 +339,7 @@ class Article(object):
                 return True
         return False
 
-    def nlp(self):
+    def nlp(self, reference_corpus=False):
         """Keyword extraction wrapper
         """
         self.throw_if_not_downloaded_verbose()
@@ -347,6 +350,12 @@ class Article(object):
         title_keyws = list(nlp.keywords(self.title).keys())
         keyws = list(set(title_keyws + text_keyws))
         self.set_keywords(keyws)
+
+        if reference_corpus:
+            title_keyws_rc = list(nlp.keywords_reference_corpus(self.title, reference_corpus).keys())
+            text_keyws_rc = list(nlp.keywords_reference_corpus(self.text, reference_corpus).keys())
+            keyws_rc = list(set(title_keyws_rc + text_keyws_rc))
+            self.set_keywords_reference_corpus(keyws_rc, reference_corpus)
 
         max_sents = self.config.MAX_SUMMARY_SENT
 
@@ -465,6 +474,14 @@ class Article(object):
             raise Exception("Keyword input must be list!")
         if keywords:
             self.keywords = keywords[:self.config.MAX_KEYWORDS]
+
+    def set_keywords_reference_corpus(self, keywords, reference_corpus):
+        """Keys are stored in list format
+        """
+        if not isinstance(keywords, list):
+            raise Exception("Keyword input must be list!")
+        if keywords:
+            self.keywords_reference_corpus = keywords[:self.config.MAX_KEYWORDS]
 
     def set_authors(self, authors):
         """Authors are in ["firstName lastName", "firstName lastName"] format

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -312,13 +312,15 @@ class ArticleTestCase(unittest.TestCase):
     @print_test
     def test_nlp_body(self):
         self.setup_stage('nlp')
-        self.article.nlp()
+        self.article.nlp(reference_corpus=os.path.join(TEST_DIR, 'data/text/space.com1.txt'))
         KEYWORDS = ['balloons', 'delays', 'flight', 'forecasters',
                     'good', 'sailing', 'smooth', 'storm', 'thanksgiving',
                     'travel', 'weather', 'winds', 'york']
+        KEYWORDS_RC = ['way', 'hit', 'night', 'snow', 'weather', 'winds', 'impact']
         SUMMARY = mock_resource_with('cnn_summary', 'txt')
         self.assertEqual(SUMMARY, self.article.summary)
         self.assertCountEqual(KEYWORDS, self.article.keywords)
+        self.assertCountEqual(KEYWORDS_RC, self.article.keywords_reference_corpus)
 
 
 class ContentExtractorTestCase(unittest.TestCase):


### PR DESCRIPTION
This pull request adds a new functionality to the NLP module that is widely used in corpus linguistics. The idea is to extracts keywords by statistically comparing a text (or corpus) to a reference corpus that is (potentially) representative of a language/genre. 

I implemented the functionality in a way that the user passes the reference corpus to the `nlp` method. I'm not perfectly clear whether this is the ideal way.

Thank you for considering!