### PR TITLE
catch TypeError for date extraction

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -183,7 +183,7 @@ class ContentExtractor(object):
             if date_str:
                 try:
                     return date_parser(date_str)
-                except (ValueError, OverflowError, AttributeError):
+                except (ValueError, OverflowError, AttributeError, TypeError):
                     # near all parse failures are due to URL dates without a day
                     # specifier, e.g. /2014/04/
                     return None


### PR DESCRIPTION
when calling `article.parse_source()` with the following url:
http://www.pulse.ng/communities/student/board-begins-2018-utme-registrations-in-700-centres-id7701350.html

a TypeError occurred. Raised by dateutil.

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-86bb2645671a> in <module>()
----> 1 res = xx.parse_source()

/opt/project/movefast/parsers/africa.py in parse_source(self)
     64             if not any(sub in item.get('guid', '') for sub in ['/bi/', '/hotpulse/']):
     65                 # ignore Business Insider and Hot! Pulse articles
---> 66                 result_object = self._parse_pulseng_source(item)
     67                 if result_object.is_valid():
     68                     results.append(result_object)

/opt/project/movefast/parsers/africa.py in _parse_pulseng_source(self, item)
     38         site_info = newspaper.Article(item.guid)
     39         site_info.download()
---> 40         site_info.parse()
     41 
     42         result_object.text = site_info.text

/usr/local/lib/python3.6/site-packages/newspaper/article.py in parse(self)
    235         self.publish_date = self.extractor.get_publishing_date(
    236             self.url,
--> 237             self.clean_doc)
    238 
    239         # Before any computations on the body, clean DOM object

/usr/local/lib/python3.6/site-packages/newspaper/extractors.py in get_publishing_date(self, url, doc)
    192         if date_match:
    193             date_str = date_match.group(0)
--> 194             datetime_obj = parse_date_str(date_str)
    195             if datetime_obj:
    196                 return datetime_obj

/usr/local/lib/python3.6/site-packages/newspaper/extractors.py in parse_date_str(date_str)
    183             if date_str:
    184                 try:
--> 185                     return date_parser(date_str)
    186                 except (ValueError, OverflowError, AttributeError):
    187                     # near all parse failures are due to URL dates without a day

/usr/local/lib/python3.6/site-packages/dateutil/parser.py in parse(timestr, parserinfo, **kwargs)
    746         return parser(parserinfo).parse(timestr, **kwargs)
    747     else:
--> 748         return DEFAULTPARSER.parse(timestr, **kwargs)
    749 
    750 

/usr/local/lib/python3.6/site-packages/dateutil/parser.py in parse(self, timestr, default, ignoretz, tzinfos, **kwargs)
    308 
    309 
--> 310         res, skipped_tokens = self._parse(timestr, **kwargs)
    311 
    312         if res is None:

TypeError: 'NoneType' object is not iterable
