### PR TITLE
Fix CI integration tests for python-2-branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+ - "2.7"
+ - "2.6"
+install:
+ - pip install -r requirements.txt coverage coveralls
+ - python download_corpora.py
+script:
+  - coverage run --source newspaper tests/unit_tests.py
+after_success:
+  coveralls


### PR DESCRIPTION
Create .travis.yml for python-2-branch to fix CI integration tests

Also cc this bug: https://github.com/codelucas/newspaper/issues/471 I am unable to reproduce issue 471 sadly.. this will at least fix CI integration to see if CI fails the installation in python 2.7 as well
cc @yprez 