### PR TITLE
Image Fetch Rework for Performance

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -252,8 +252,7 @@ class Article(object):
             self.set_article_html(article_html)
             self.set_text(text)
 
-        if self.config.fetch_images:
-            self.fetch_images()
+        self.fetch_images()
 
         self.is_parsed = True
         self.release_resources()
@@ -272,9 +271,12 @@ class Article(object):
         if self.clean_top_node is not None and not self.has_top_image():
             first_img = self.extractor.get_first_img_url(
                 self.url, self.clean_top_node)
-            self.set_top_img(first_img)
+            if self.config.fetch_images:
+                self.set_top_img(first_img)
+            else:
+                self.set_top_img_no_check(first_img)
 
-        if not self.has_top_image():
+        if not self.has_top_image() and self.config.fetch_images:
             self.set_reddit_top_img()
 
     def has_top_image(self):
@@ -436,7 +438,8 @@ class Article(object):
 
     def set_meta_img(self, src_url):
         self.meta_img = src_url
-        self.set_top_img_no_check(src_url)
+        if images.valid_image_url(src_url):
+            self.set_top_img_no_check(src_url)
 
     def set_top_img(self, src_url):
         if src_url is not None:

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -22,6 +22,7 @@ from tldextract import tldextract
 from urllib.parse import urljoin, urlparse, urlunparse
 
 from . import urls
+from .images import valid_image_url
 from .utils import StringReplacement, StringSplitter
 
 log = logging.getLogger(__name__)
@@ -567,7 +568,7 @@ class ContentExtractor(object):
         urls = [img_tag.get('src')
                 for img_tag in img_tags if img_tag.get('src')]
         img_links = set([urljoin(article_url, url)
-                         for url in urls])
+                         for url in urls if valid_image_url(url)])
         return img_links
 
     def get_first_img_url(self, article_url, top_node):

--- a/newspaper/images.py
+++ b/newspaper/images.py
@@ -27,7 +27,7 @@ chunk_size = 1024
 thumbnail_size = 90, 90
 minimal_area = 5000
 
-BAD_URLS = ['logo', 'icon', 'banner', 'ribbon', 'asset', 'sprite', 'qrcode']
+BAD_URLS = ['logo', 'icon', 'banner', 'ribbon', 'sprite', 'qrcode']
 ALLOWED_TYPES = ['jpg', 'jpeg', 'png']
 
 def image_to_str(image):
@@ -189,7 +189,7 @@ def valid_image_url(url):
     # '/story/cnn/blahblah/index.html' --> ['story', 'cnn', 'blahblah', 'index.html']
     path_chunks = [x for x in path.split('/') if len(x) > 0]
 
-    # siphon out the file type. eg: .html, .htm, .md
+    # siphon out the file type. eg: jpeg, png
     if len(path_chunks) > 0:
         file_type = urls.url_to_filetype(url)
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -216,7 +216,7 @@ class ArticleTestCase(unittest.TestCase):
         AUTHORS = ['Chien-Ming Wang', 'Dana A. Ford', 'James S.A. Corey',
                    'Tom Watkins']
         TITLE = 'After storm, forecasters see smooth sailing for Thanksgiving'
-        LEN_IMGS = 46
+        LEN_IMGS = 40 # Based on page and valid_image_url rules
         META_LANG = 'en'
 
         self.article.parse()


### PR DESCRIPTION
This is my work in an attempt to address #483.

The Image Fetch configuration now only controls whether images will be downloaded. If fetching images is false in the configuration, images will still be returned analyzed through the other methods (top node etc). It is possible for top_image to be `None` if it can not be determined w/o fetching.

Image fetch when true (left default) will still work as previous, except that image URLs may still be checked for validity based on the valid URL heuristics.

This also adds a new heuristic around valid image urls. It is written in a very similar way to regular link validity, just tuned initially for images.

This PR has been required for me to use newspaper on a large volume of URLs without certain urls causing blocks.