### PR TITLE
Update ReadMe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ A Glance:
 
     >>> import newspaper
 
-    >>> cnn_paper = newspaper.build('http://cnn.com')
+    >>> cnn_paper = newspaper.build('http://edition.cnn.com')
 
     >>> for article in cnn_paper.articles:
     >>>     print(article.url)


### PR DESCRIPTION
The example used in the README file, http://cnn.com does not actually work. 
CNN now keeps their news articles at http://edition.cnn.com .
If you type cnn.com into a browser, you get redirected to edition.cnn.com