### PR TITLE
Differentiate strict and non-strict date regex filters/extractors.

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -188,7 +188,7 @@ class ContentExtractor(object):
                     # specifier, e.g. /2014/04/
                     return None
 
-        date_match = re.search(urls.DATE_REGEX, url)
+        date_match = re.search(urls.STRICT_DATE_REGEX, url)
         if date_match:
             date_str = date_match.group(0)
             datetime_obj = parse_date_str(date_str)

--- a/newspaper/urls.py
+++ b/newspaper/urls.py
@@ -20,7 +20,9 @@ log = logging.getLogger(__name__)
 
 MAX_FILE_MEMO = 20000
 
-DATE_REGEX = r'(?<=\W)([\./\-_]{0,1}(19|20)\d{2})[\./\-_]{0,1}(([0-3]{0,1}[0-9][\./\-_])|(\w{3,5}[\./\-_]))([0-3]{0,1}[0-9][\./\-]{0,1})?'
+_STRICT_DATE_REGEX_PREFIX = r'(?<=\W)'
+DATE_REGEX = r'([\./\-_]{0,1}(19|20)\d{2})[\./\-_]{0,1}(([0-3]{0,1}[0-9][\./\-_])|(\w{3,5}[\./\-_]))([0-3]{0,1}[0-9][\./\-]{0,1})?'
+STRICT_DATE_REGEX = _STRICT_DATE_REGEX_PREFIX + DATE_REGEX
 
 ALLOWED_TYPES = ['html', 'htm', 'md', 'rst', 'aspx', 'jsp', 'rhtml', 'cgi',
                  'xhtml', 'jhtml', 'asp']

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -523,7 +523,7 @@ class UrlTestCase(unittest.TestCase):
     @print_test
     def test_pubdate(self):
         """Checks that irrelevant data in url isn't considered as publishing date"""
-        from newspaper.urls import DATE_REGEX
+        from newspaper.urls import STRICT_DATE_REGEX
 
         with open(os.path.join(TEST_DIR, 'data/test_urls_pubdate.txt'), 'r') as f:
             lines = f.readlines()
@@ -533,7 +533,7 @@ class UrlTestCase(unittest.TestCase):
 
             for pubdate, url in test_tuples:
                 is_present = bool(int(pubdate))
-                date_match = re.search(DATE_REGEX, url)
+                date_match = re.search(STRICT_DATE_REGEX, url)
                 try:
                     self.assertEqual(is_present, bool(date_match))
                 except AssertionError:


### PR DESCRIPTION
I think using the new strict `DATE_REGEX` introduced in https://github.com/codelucas/newspaper/pull/301 on both url filtering and also publisher date extraction is too strict. Let's only use the strict version for publisher date extraction since room for error on url filtering (determining if a url is newsy) has very little room for error.