### PR TITLE
Adjustments to extract full text of an article from The Atlantic.

### DIFF
--- a/newspaper/cleaners.py
+++ b/newspaper/cleaners.py
@@ -27,7 +27,7 @@ class DocumentCleaner(object):
             "|communitypromo|runaroundLeft|subscribe|vcard|articleheadings"
             "|date|^print$|popup|author-dropdown|tools|socialtools|byline"
             "|konafilter|KonaFilter|breadcrumbs|^fn$|wp-caption-text"
-            "|legende|ajoutVideo|timestamp|js_replies"
+            "|legende|ajoutVideo|timestamp|js_replies|^ad-box"
         )
         self.regexp_namespace = "http://exslt.org/regular-expressions"
         self.nauthy_ids_re = ("//*[re:test(@id, '%s', 'i')]" %

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -817,7 +817,7 @@ class ContentExtractor(object):
             parent_parent_node = self.parser.getParent(parent_node)
             if parent_parent_node is not None:
                 self.update_node_count(parent_parent_node, 1)
-                self.update_score(parent_parent_node, upscore / 2)
+                self.update_score(parent_parent_node, upscore / 1.7)
                 if parent_parent_node not in parent_nodes:
                     parent_nodes.append(parent_parent_node)
             cnt += 1

--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -9,6 +9,7 @@ __copyright__ = 'Copyright 2014, Lucas Ou-Yang'
 
 from html import unescape
 import logging
+import re
 
 from .text import innerTrim
 
@@ -158,10 +159,24 @@ class OutputFormatter(object):
                     max_depth = e_depth
             return max_depth
 
+        def get_id_strip_digit(node):
+            node_id = node.get('id')
+            if node_id:
+                return re.match('^(.+*)\d*', node_id).group(1)
+
         top_level_nodes = self.parser.getChildren(self.get_top_node())
         if len(top_level_nodes) < 3:
             return
 
+        other = top_level_nodes[:-1]
         last_node = top_level_nodes[-1]
+
+        same_tag = all(node.tag == last_node.tag for node in other)
+        same_class = all(node.get('class') == last_node.get('class') for node in other)
+        similar_id = all(get_id_strip_digit(node) == get_id_strip_digit(last_node) for node in other)
+
+        if same_tag and same_class and similar_id:
+            return
+
         if get_depth(last_node) >= 2:
             self.parser.remove(last_node)


### PR DESCRIPTION
This is my test case: https://www.theatlantic.com/politics/archive/2018/02/pageantry-military-parades/552953/

The article appears in three sections with adverts between them. The code was picking just the first section. These three changes mean that the full article text is selected.