### PR TITLE
Allow configuration of base directory

### DIFF
--- a/newspaper/settings.py
+++ b/newspaper/settings.py
@@ -34,7 +34,9 @@ DATA_DIRECTORY = '.newspaper_scraper'
 
 
 if 'LAMBDA_TASK_ROOT' in os.environ:
-    BASE_DIRECTORY = os.environ['LAMBDA_TASK_ROOT']
+    # https://docs.aws.amazon.com/lambda/latest/dg/limits.html
+    # only /tmp is writeable in lambda
+    BASE_DIRECTORY = "/tmp"
 else:
     BASE_DIRECTORY = tempfile.gettempdir()
 

--- a/newspaper/settings.py
+++ b/newspaper/settings.py
@@ -33,8 +33,8 @@ NLP_STOPWORDS_EN = os.path.join(
 DATA_DIRECTORY = '.newspaper_scraper'
 
 
-if 'NEWSPAPER_SCRAPER_BASE_DIRECTORY' in os.environ:
-    BASE_DIRECTORY = os.environ['NEWSPAPER_SCRAPER_BASE_DIRECTORY']
+if 'LAMBDA_TASK_ROOT' in os.environ:
+    BASE_DIRECTORY = os.environ['LAMBDA_TASK_ROOT']
 else:
     BASE_DIRECTORY = tempfile.gettempdir()
 

--- a/newspaper/settings.py
+++ b/newspaper/settings.py
@@ -32,7 +32,13 @@ NLP_STOPWORDS_EN = os.path.join(
 
 DATA_DIRECTORY = '.newspaper_scraper'
 
-TOP_DIRECTORY = os.path.join(tempfile.gettempdir(), DATA_DIRECTORY)
+
+if 'NEWSPAPER_SCRAPER_BASE_DIRECTORY' in os.environ:
+    BASE_DIRECTORY = os.environ['NEWSPAPER_SCRAPER_BASE_DIRECTORY']
+else:
+    BASE_DIRECTORY = tempfile.gettempdir()
+
+TOP_DIRECTORY = os.path.join(BASE_DIRECTORY, DATA_DIRECTORY)
 if not os.path.exists(TOP_DIRECTORY):
     os.mkdir(TOP_DIRECTORY)
 

--- a/newspaper/settings.py
+++ b/newspaper/settings.py
@@ -33,10 +33,10 @@ NLP_STOPWORDS_EN = os.path.join(
 DATA_DIRECTORY = '.newspaper_scraper'
 
 
-if 'LAMBDA_TASK_ROOT' in os.environ:
+if 'NEWSPAPER_BASE_DIRECTORY' in os.environ:
     # https://docs.aws.amazon.com/lambda/latest/dg/limits.html
     # only /tmp is writeable in lambda
-    BASE_DIRECTORY = "/tmp"
+    BASE_DIRECTORY = os.environ['NEWSPAPER_BASE_DIRECTORY']
 else:
     BASE_DIRECTORY = tempfile.gettempdir()
 


### PR DESCRIPTION
I was able to make newspaper work on aws lambda with this PR update and the following code


```
# only /tmp is writable on lambda env
os.environ['NEWSPAPER_BASE_DIRECTORY'] = '/tmp'
os.environ['NLTK_DATA'] = '/tmp'

# https://stackoverflow.com/a/44532317/2523414
# no sqlite in lambda, needed by a small subset of nltk
import imp
import sys
sys.modules["sqlite"] = imp.new_module("sqlite")
sys.modules["sqlite3.dbapi2"] = imp.new_module("sqlite.dbapi2")

from newspaper import Article
import nltk
nltk.download('punkt')
```

This PR is also handy for AWS Beanstalk as the `/home/wsgi` folder do not exists and you also need to configure the directory