### PR TITLE
StopWordsKorean class bug

### DIFF
--- a/newspaper/text.py
+++ b/newspaper/text.py
@@ -149,8 +149,9 @@ class StopWordsKorean(StopWords):
         c = 0
         for w in candidate_words:
             c += 1
-            if w in self.STOP_WORDS:
-                overlapping_stopwords.append(w)
+            for s in self.STOP_WORDS:
+                if w.endswith(s):
+                    overlapping_stopwords.append(w)
 
         ws.set_word_count(c)
         ws.set_stopword_count(len(overlapping_stopwords))


### PR DESCRIPTION
#### Fixed Bug in StopWordKorean class
fixed bug in StopWordsKorean class that original code did not find stopwords in words.
StopWordsHindi class also seems like having the same problem but did not fix it.

#### Enhancement in StopWordKorean class
Korean is composed of 'noun'+'postposition'.
Postposition acts like stopwords in English.
For example, to him' is '그에게'(그(he)+에게(to)) in Korean. 에게(to) is a  #stopword.
So, we can detect stopwords mostly by checking whether the last characters in Korean words are stopwords.