### PR TITLE
Enable async downloading of individually specified articles

### DIFF
--- a/newspaper/mthreading.py
+++ b/newspaper/mthreading.py
@@ -15,7 +15,6 @@ from threading import Thread
 
 from .configuration import Configuration
 
-
 class Worker(Thread):
     """
     Thread executing tasks from a given tasks queue.
@@ -105,4 +104,7 @@ class NewsPool(object):
         self.pool = ThreadPool(num_threads, timeout)
 
         for paper in self.papers:
-            self.pool.add_task(paper.download_articles)
+            try:
+                self.pool.add_task(paper.download_articles)
+            except AttributeError:
+                self.pool.add_task(paper.download)


### PR DESCRIPTION
The docstring of `newspaper.mthreading.NewsPool.__init__` appears to indicate that one can pass it a list of source or article objects. The class implementation, however, cannot handle article objects; I modified `newspaper.mthreading.NewsPool.set` to remedy this.