### PR TITLE
implementing 3rd method of publish date extraction (issue # 521)

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -182,7 +182,9 @@ class ContentExtractor(object):
         def parse_date_str(date_str):
             if date_str:
                 try:
-                    return date_parser(date_str)
+                    # define dictionary for timezones not part of dateutil's defaults
+                    tzinfo = {"ET" : "EST"}
+                    return date_parser(date_str, tzinfos = tzinfo, fuzzy = True)
                 except (ValueError, OverflowError, AttributeError, TypeError):
                     # near all parse failures are due to URL dates without a day
                     # specifier, e.g. /2014/04/
@@ -229,6 +231,32 @@ class ContentExtractor(object):
                 datetime_obj = parse_date_str(date_str)
                 if datetime_obj:
                     return datetime_obj
+
+        # search article body for the publication date:
+
+        # attributes and values determined from scouring "most popular news
+        # websites in the U.S." @ https://www.kadaza.com/news
+        # nbcnews.com uses _3OViwiRtR_PFko9i8o9Mov as a class name for their dates
+        ATTRS = ['class', 'id'] 
+        VALS = ['date', 'timestamp', 'time', '_3OViwiRtR_PFko9i8o9Mov', 'ra-date-published']
+        matches = []
+
+        for attr in ATTRS:
+            for val in VALS:
+                found = self.parser.getElementsByTag(doc, attr=attr, value=val)
+                matches.extend(found)
+
+        for match in matches:
+            content = ''
+            if match.tag == 'meta':
+                mm = match.xpath('@content')
+                if len(mm) > 0:
+                    content = mm[0]
+            else:
+                content = match.text or ''
+            datetime_object = parse_date_str(content)
+            if datetime_object:
+                return datetime_object
 
         return None
 


### PR DESCRIPTION
I tested the original version and this modified version on 120 different news articles across multiple sites. This version successfully parsed 119 of the publish dates, compared to 84 from the previous version. On average, the runtime increase is only marginal for the accuracy increase.

Final statistics from testing:

-------------------------------                                                                               
urls that failed both versions:                                                                               
-------------------------------                                                                               
https://www.bbcgoodfood.com/howto/guide/top-10-retro-british-desserts                                         
-------------------------------                                                                               
success rates of original/modified versions:                                                                  
-------------------------------                                                                               
original version successes:  84  /  120                                                                       
updated version successes:  119  /  120                                                                       
accuracy improvement percentage:  0.41666666666666674                                                         
-------------------------------                                                                               
average abolute/relative runtime differences:                                                                 
-------------------------------                                                                               
dataset:  |  absolute difference:     | relative difference:                                                  
original: |  0.004801957380203973  |  0.008619953698073361                                                    
new :     |  0.01785543305533273  |  0.1452353506990094                                                       
fails:    |  0.0388028621673584  |  0.19184348967941411                                                       
total:    |  0.00889256199200948  |  0.04999297395652421        

.

The url that failed is one that was linked to on an aggregated-link-based news site. On inspection of the source code, no evidence of a publish date was found.

Statistic explanation:

Datasets:
    - original: urls that worked in the original version
    - new: urls that failed the original, but passed in the new version
    - fails: urls that failed both versions
    - total: all urls used
Abolute Difference:
    - runtime differences from executing article.parse()
    - calculated using python's time.time() function
    - difference = new runtime - original runtime
Relatvie Difference:
    - difference = absolute difference / original runtime

Summary:
    The modified version found publish dates for ~42% more articles and, on average, increased the runtime of article.parse() by only ~5%