### PR TITLE
Added support for multi-threaded Article downloading

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -143,15 +143,16 @@ class Article(object):
         # A property dict for users to store custom data.
         self.additional_data = {}
 
-    def build(self):
+    def build(self, with_nlp=True):
         """Build a lone article from a URL independent of the source (newspaper).
         Don't normally call this method b/c it's good to multithread articles
         on a source (newspaper) level.
         """
         self.download()
         self.parse()
-        self.nlp()
-
+        if with_nlp:
+            self.nlp()
+    
     def download(self, input_html=None, title=None, recursion_counter=0):
         """Downloads the link's HTML content, don't use if you are batch async
         downloading articles
@@ -521,7 +522,7 @@ class Article(object):
         """
         if self.download_state == ArticleDownloadState.NOT_STARTED:
             print('You must `download()` an article first!')
-            raise ArticleException()
+            #raise ArticleException()
         elif self.download_state == ArticleDownloadState.FAILED_RESPONSE:
             print('Article `download()` failed with %s on URL %s' %
                   (self.download_exception_msg, self.url))

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -522,7 +522,7 @@ class Article(object):
         """
         if self.download_state == ArticleDownloadState.NOT_STARTED:
             print('You must `download()` an article first!')
-            #raise ArticleException()
+            raise ArticleException()
         elif self.download_state == ArticleDownloadState.FAILED_RESPONSE:
             print('Article `download()` failed with %s on URL %s' %
                   (self.download_exception_msg, self.url))

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -68,6 +68,7 @@ class Configuration(object):
         self.request_timeout = 7
         self.proxies = {}
         self.number_threads = 10
+        self.max_number_threads = 128
 
         self.verbose = False  # for debugging
 

--- a/newspaper/mthreading.py
+++ b/newspaper/mthreading.py
@@ -116,3 +116,4 @@ class NewsPool(object):
 
         for article in self.articles:
             self.pool.add_task(article.download)
+            self.pool.add_task(article.parse)

--- a/newspaper/mthreading.py
+++ b/newspaper/mthreading.py
@@ -112,7 +112,8 @@ class NewsPool(object):
     def set_articles(self, article_list):
         self.articles = article_list
         timeout = self.config.thread_timeout_seconds
-        self.pool = ThreadPool(len(articles), timeout)
+        num_threads = len(self.articles) if len(self.articles <= self.config.max_number_threads) else self.config.max_number_threads
+        self.pool = ThreadPool(num_threads, timeout)
 
         for article in self.articles:
             self.pool.add_task(article.download)

--- a/newspaper/mthreading.py
+++ b/newspaper/mthreading.py
@@ -112,7 +112,7 @@ class NewsPool(object):
     def set_articles(self, article_list):
         self.articles = article_list
         timeout = self.config.thread_timeout_seconds
-        self.pool = ThreadPool(1, timeout)
+        self.pool = ThreadPool(len(articles), timeout)
 
         for article in self.articles:
             self.pool.add_task(article.download)

--- a/newspaper/mthreading.py
+++ b/newspaper/mthreading.py
@@ -112,7 +112,7 @@ class NewsPool(object):
     def set_articles(self, article_list):
         self.articles = article_list
         timeout = self.config.thread_timeout_seconds
-        num_threads = len(self.articles) if len(self.articles <= self.config.max_number_threads) else self.config.max_number_threads
+        num_threads = len(self.articles) if len(self.articles) <= self.config.max_number_threads) else self.config.max_number_threads
         self.pool = ThreadPool(num_threads, timeout)
 
         for article in self.articles:

--- a/newspaper/mthreading.py
+++ b/newspaper/mthreading.py
@@ -116,4 +116,4 @@ class NewsPool(object):
         self.pool = ThreadPool(num_threads, timeout)
 
         for article in self.articles:
-            self.pool.add_task(article.build, args=(False))
+            self.pool.add_task(article.build, (False))

--- a/newspaper/mthreading.py
+++ b/newspaper/mthreading.py
@@ -112,7 +112,7 @@ class NewsPool(object):
     def set_articles(self, article_list):
         self.articles = article_list
         timeout = self.config.thread_timeout_seconds
-        num_threads = len(self.articles) if len(self.articles) <= self.config.max_number_threads) else self.config.max_number_threads
+        num_threads = len(self.articles) if len(self.articles) <= self.config.max_number_threads else self.config.max_number_threads
         self.pool = ThreadPool(num_threads, timeout)
 
         for article in self.articles:

--- a/newspaper/mthreading.py
+++ b/newspaper/mthreading.py
@@ -92,8 +92,9 @@ class NewsPool(object):
         resets the task.
         """
         if self.pool is None and self.articles is None:
-            print('Call set(..) or set_articles(...) with a list of source '
-                  'objects before .join(..)')
+            print('Call set(..) with a list of source objects '
+                  'or set_articles(...) with a list of article objects '
+                  'before .join(..)')
             raise
         self.pool.wait_completion()
         self.papers = []

--- a/newspaper/mthreading.py
+++ b/newspaper/mthreading.py
@@ -92,7 +92,7 @@ class NewsPool(object):
         resets the task.
         """
         if self.pool is None and self.articles is None:
-            print('Call set_papers(..) or set_articles(...) with a list of source '
+            print('Call set(..) or set_articles(...) with a list of source '
                   'objects before .join(..)')
             raise
         self.pool.wait_completion()
@@ -100,7 +100,7 @@ class NewsPool(object):
         self.articles = []
         self.pool = None
 
-    def set_papers(self, paper_list, threads_per_source=1):
+    def set(self, paper_list, threads_per_source=1):
         self.papers = paper_list
         num_threads = threads_per_source * len(self.papers)
         timeout = self.config.thread_timeout_seconds
@@ -116,5 +116,4 @@ class NewsPool(object):
         self.pool = ThreadPool(num_threads, timeout)
 
         for article in self.articles:
-            self.pool.add_task(article.download)
-            self.pool.add_task(article.parse)
+            self.pool.add_task(article.build, args=(False))

--- a/newspaper/mthreading.py
+++ b/newspaper/mthreading.py
@@ -82,6 +82,7 @@ class NewsPool(object):
         u'<html>blahblah ... '
         """
         self.papers = []
+        self.articles = []
         self.pool = None
         self.config = config or Configuration()
 
@@ -90,15 +91,16 @@ class NewsPool(object):
         Runs the mtheading and returns when all threads have joined
         resets the task.
         """
-        if self.pool is None:
-            print('Call set(..) with a list of source '
+        if self.pool is None and self.articles is None:
+            print('Call set_papers(..) or set_articles(...) with a list of source '
                   'objects before .join(..)')
             raise
         self.pool.wait_completion()
         self.papers = []
+        self.articles = []
         self.pool = None
 
-    def set(self, paper_list, threads_per_source=1):
+    def set_papers(self, paper_list, threads_per_source=1):
         self.papers = paper_list
         num_threads = threads_per_source * len(self.papers)
         timeout = self.config.thread_timeout_seconds
@@ -106,3 +108,11 @@ class NewsPool(object):
 
         for paper in self.papers:
             self.pool.add_task(paper.download_articles)
+
+    def set_articles(self, article_list):
+        self.articles = article_list
+        timeout = self.config.thread_timeout_seconds
+        self.pool = ThreadPool(1, timeout)
+
+        for article in self.articles:
+            self.pool.add_task(article.download)


### PR DESCRIPTION
In the `mthreading.py` class, the NewsPool object description is as follows:

```
Abstraction of a threadpool. A newspool can accept any number of
source OR article objects together in a list. It allocates one
thread to every source and then joins.
```

However, I noticed it could not support the the inclusion of `Article` objects because the method passed to `pool.add_task` is `Source.download_articles()`. When passing a list of `Article`s, this this line throws an exception.

What I've done is added some minor, non breaking changes to support multithreaded `Article` downloading, identical to how it can be done with `Source`s. Below is a summary of changes:
- [Added a `set_articles` method and `articles` property to the `NewsPool` class](https://github.com/codelucas/newspaper/compare/master...Briscoooe:master#diff-125b00b6b6bf2170179699d51bfbfd8c)
- [Added a `with_nlp` argument to the `Article.build()` method with a default value of `True`, so as not to break any existing code](https://github.com/codelucas/newspaper/compare/master...Briscoooe:master#diff-58c6e0d178f563a62a6450c669930681)
- [Added a max number of threads to the default config](https://github.com/codelucas/newspaper/compare/master...Briscoooe:master#diff-8c4b8ecb8a8e68e766479760763fa8d0)