### PR TITLE
Fix get_html_2XX_only exceptions masking

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -520,17 +520,14 @@ class Article(object):
         -> maybe throw ArticleException
         """
         if self.download_state == ArticleDownloadState.NOT_STARTED:
-            print('You must `download()` an article first!')
-            raise ArticleException()
+            raise ArticleException('You must `download()` an article first!')
         elif self.download_state == ArticleDownloadState.FAILED_RESPONSE:
-            print('Article `download()` failed with %s on URL %s' %
+            raise ArticleException('Article `download()` failed with %s on URL %s' %
                   (self.download_exception_msg, self.url))
-            raise ArticleException()
 
     def throw_if_not_parsed_verbose(self):
         """Parse `is_parsed` status -> log readable status 
         -> maybe throw ArticleException
         """
         if not self.is_parsed:
-            print('You must `parse()` an article first!')
-            raise ArticleException()
+            raise ArticleException('You must `parse()` an article first!')

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -59,12 +59,8 @@ def get_html_2XX_only(url, config=None, response=None):
     if response is not None:
         return _get_html_from_response(response)
 
-    try:
-        response = requests.get(
-            url=url, **get_request_kwargs(timeout, useragent, proxies, headers))
-    except requests.exceptions.RequestException as e:
-        log.debug('get_html_2XX_only() error. %s on URL: %s' % (e, url))
-        return ''
+    response = requests.get(
+        url=url, **get_request_kwargs(timeout, useragent, proxies, headers))
 
     html = _get_html_from_response(response)
 


### PR DESCRIPTION
get_html_2XX_only in network.py masks all exceptions, so it was no possibilities to get the real error message in "outside code".