### PR TITLE
Added auto language detection when language isn't in meta data

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -10,6 +10,7 @@ import os
 import glob
 
 import requests
+from langdetect import detect
 
 from . import images
 from . import network
@@ -210,6 +211,14 @@ class Article(object):
         if self.config.use_meta_language:
             self.extractor.update_language(self.meta_lang)
             output_formatter.update_language(self.meta_lang)
+
+            # If there is no meta language provide, but detect_lang_from_title is true, and there is title text, try to detect language
+            if not self.meta_lang and self.config.detect_lang_from_title and self.title:
+                detected_lang = detect(self.title)
+                # Make sure the detected language is an available language, or don't use it
+                if detected_lang in get_available_languages():
+                    self.extractor.update_language(detected_lang)
+                    output_formatter.update_language(detected_lang)
 
         meta_favicon = self.extractor.get_favicon(self.clean_doc)
         self.set_meta_favicon(meta_favicon)

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -51,6 +51,9 @@ class Configuration(object):
         # Don't toggle this variable, done internally
         self.use_meta_language = True
 
+        # If use_meta_language is true but cannot be parsed, try detecting lang from title
+        self.detect_lang_from_title = True
+
         # You may keep the html of just the main article body
         self.keep_article_html = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tldextract>=2.0.1
 feedfinder2>=0.0.4
 jieba3k>=0.35.1
 python-dateutil>=2.5.3
+langdetect>=1.0.7


### PR DESCRIPTION
If the meta data language can't be found, and the language wasn't provided by the user, then try to detect the language of the article from the title text. If the language detected is in the list of available languages, use it, if it's not in the list don't use it.