### PR TITLE
Add publish_time_telegram to publish_date tags

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -216,6 +216,8 @@ class ContentExtractor(object):
              'content': 'content'},
             {'attribute': 'pubdate', 'value': 'pubdate',
              'content': 'datetime'},
+            {'attribute': 'name', 'value': 'published_time_telegram',
+             'content': 'content'},
         ]
         for known_meta_tag in PUBLISH_DATE_TAGS:
             meta_tags = self.parser.getElementsByTag(


### PR DESCRIPTION
Add the `publish_time_telegram` tag to the list of possible tags containing the published date.

```python
from newspaper import Article

article = Article(url="https://www.rt.com/uk/434030-sharks-british-waters-devon/")
article.download()
article.parse()
print(article.publish_date)
```