### PR TITLE
Use try except on creating dirs to avoid FileExistsError

### DIFF
--- a/newspaper/settings.py
+++ b/newspaper/settings.py
@@ -33,8 +33,6 @@ NLP_STOPWORDS_EN = os.path.join(
 DATA_DIRECTORY = '.newspaper_scraper'
 
 TOP_DIRECTORY = os.path.join(tempfile.gettempdir(), DATA_DIRECTORY)
-if not os.path.exists(TOP_DIRECTORY):
-    os.mkdir(TOP_DIRECTORY)
 
 # Error log
 LOGFILE = os.path.join(TOP_DIRECTORY, 'newspaper_errors_%s.log' % __version__)
@@ -45,14 +43,14 @@ MONITOR_LOGFILE = os.path.join(
 MEMO_FILE = 'memoized'
 MEMO_DIR = os.path.join(TOP_DIRECTORY, MEMO_FILE)
 
-if not os.path.exists(MEMO_DIR):
-    os.mkdir(MEMO_DIR)
-
 # category and feed cache
 CF_CACHE_DIRECTORY = 'feed_category_cache'
 ANCHOR_DIRECTORY = os.path.join(TOP_DIRECTORY, CF_CACHE_DIRECTORY)
 
-if not os.path.exists(ANCHOR_DIRECTORY):
-    os.mkdir(ANCHOR_DIRECTORY)
-
 TRENDING_URL = 'http://www.google.com/trends/hottrends/atom/feed?pn=p1'
+
+for path in (TOP_DIRECTORY, MEMO_DIR, ANCHOR_DIRECTORY):
+    try:
+        os.mkdir(path)
+    except FileExistsError:
+        pass


### PR DESCRIPTION
Because of race condition sometimes we get FileExistsError while running tests in parallel:

    fetch.py:13: in <module>
        from newspaper import Article
    /usr/local/lib/python3.6/dist-packages/newspaper/__init__.py:10: in <module>
        from .api import (build, build_article, fulltext, hot, languages,
    /usr/local/lib/python3.6/dist-packages/newspaper/api.py:14: in <module>
        from .article import Article
    /usr/local/lib/python3.6/dist-packages/newspaper/article.py:15: in <module>
        from . import network
    /usr/local/lib/python3.6/dist-packages/newspaper/network.py:14: in <module>
        from .configuration import Configuration
    /usr/local/lib/python3.6/dist-packages/newspaper/configuration.py:15: in <module>
        from .parsers import Parser
    /usr/local/lib/python3.6/dist-packages/newspaper/parsers.py:20: in <module>
        from . import text
    /usr/local/lib/python3.6/dist-packages/newspaper/text.py:14: in <module>
        from .utils import FileHelper
    /usr/local/lib/python3.6/dist-packages/newspaper/utils.py:27: in <module>
        from . import settings
    /usr/local/lib/python3.6/dist-packages/newspaper/settings.py:37: in <module>
        os.mkdir(TOP_DIRECTORY)
    E   FileExistsError: [Errno 17] File exists: '/tmp/.newspaper_scraper'