### PR TITLE
Add "byl" attr val to byline parsing. Fixes nytimes.com author parsing.

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -136,7 +136,7 @@ class ContentExtractor(object):
         # Try 1: Search popular author tags for authors
 
         ATTRS = ['name', 'rel', 'itemprop', 'class', 'id']
-        VALS = ['author', 'byline', 'dc.creator']
+        VALS = ['author', 'byline', 'dc.creator', 'byl']
         matches = []
         authors = []
 


### PR DESCRIPTION
Articles on nytimes.com use a meta tag with `name="byl"` to hold the byline, ex. `<meta data-rh="true" name="byl" content="By Manny Fernandez and Ilana Panich-Linsman"/>`. Adding `'byl'` to `VALS` in `ContentExtractor.get_authors` picks up this meta tag.

```
# Before
>>> url = 'https://www.nytimes.com/2018/09/02/us/politics/judge-kavanaugh-supreme-court-justices.html'
>>> article = newspaper.Article(url)
>>> article.build()
>>> article.authors
[]
# After
>>> article = newspaper.Article(url)
>>> article.build()
>>> article.authors
['Adam Liptak']