### PR TITLE
Add `Article` constructor param sanitization guards

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -45,6 +45,12 @@ class Article(object):
         """The **kwargs argument may be filled with config values, which
         is added into the config object
         """
+        if isinstance(title, Configuration) or \
+                isinstance(source_url, Configuration):
+            raise ArticleException(
+                'Configuration object being passed incorrectly as title or '
+                'source_url! Please verify `Article`s __init__() fn.')
+
         self.config = config or Configuration()
         self.config = extend_config(self.config, kwargs)
 
@@ -343,7 +349,7 @@ class Article(object):
         """
         self.throw_if_not_downloaded_verbose()
         self.throw_if_not_parsed_verbose()
-        
+
         nlp.load_stopwords(self.config.get_language())
         text_keyws = list(nlp.keywords(self.text).keys())
         title_keyws = list(nlp.keywords(self.title).keys())
@@ -526,7 +532,7 @@ class Article(object):
                   (self.download_exception_msg, self.url))
 
     def throw_if_not_parsed_verbose(self):
-        """Parse `is_parsed` status -> log readable status 
+        """Parse `is_parsed` status -> log readable status
         -> maybe throw ArticleException
         """
         if not self.is_parsed:


### PR DESCRIPTION
This PR will fix/address the pattern of issues arisen in https://github.com/codelucas/newspaper/issues/562.

This issue is partly a problem with the API since the `Article` constructor is so brittle, it can take totally incorrect types for input params and still fail silently, misleading the user.

Also remove whitespace.