### PR TITLE
Skip removing last diff it it's known that it has non-media class

### DIFF
--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -141,8 +141,11 @@ class OutputFormatter(object):
     def remove_trailing_media_div(self):
         """Punish the *last top level* node in the top_node if it's
         DOM depth is too deep. Many media non-content links are
-        eliminated: "related", "loading gallery", etc
+        eliminated: "related", "loading gallery", etc. It skips removal if
+        last top level node's class is one of NON_MEDIA_CLASSES.
         """
+
+        NON_MEDIA_CLASSES = ('zn-body__read-all', )
 
         def get_depth(node, depth=1):
             """Computes depth of an lxml element via BFS, this would be
@@ -163,5 +166,10 @@ class OutputFormatter(object):
             return
 
         last_node = top_level_nodes[-1]
+
+        last_node_class = self.parser.getAttribute(last_node, 'class')
+        if last_node_class in NON_MEDIA_CLASSES:
+            return
+
         if get_depth(last_node) >= 2:
             self.parser.remove(last_node)


### PR DESCRIPTION
Hello,

while trying to handle articles from CNN, we stumbled across issue with skipping part of the article, after investigation it turned out that it was because of too agressive removal of last div, which is adjusted in the following PR. Keep in mind that this is only a proposition of implementation and I would love to discuss other possible approaches. I can confirm that this solves following issue: https://github.com/codelucas/newspaper/issues/560

Example articles that had this issue:
https://edition.cnn.com/2017/01/30/politics/trump-immigration-ban-refugees-trnd/index.html
https://edition.cnn.com/2018/08/21/us/colorado-chris-watts-court/index.html

Moreover, during testing I noticed that current master has failing `fulltext` tests which are also not run on Travis, which has been filled in form of following issues:
https://github.com/codelucas/newspaper/issues/632
https://github.com/codelucas/newspaper/issues/631

Let me know if I can help with fixing them/improving CI setup, I would love to contribute here.

Regards,
Piotr