### PR TITLE
Included 'span' and 'a'

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -148,7 +148,7 @@ class ContentExtractor(object):
 
         for match in matches:
             content = ''
-            if match.tag == 'meta':
+            if match.tag == 'meta' or match.tag == 'span' or match.tag == 'a':
                 mm = match.xpath('@content')
                 if len(mm) > 0:
                     content = mm[0]


### PR DESCRIPTION
Sometimes author names are included inside span and a. So modified the code. 
Can also include div if necessary