### PR TITLE
Ignoring http pages depending on their content-type

### DIFF
--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -148,6 +148,25 @@ Initializing an ``Article`` by itself.
 
 Note the similar ``language=`` named paramater above. All the config parameters as described for ``Source`` objects also apply for ``Article`` objects! **Source and Article objects have a very similar api**.
 
+Initializing an ``Article`` with the particular content-type ignoring.
+
+There is option to skip loading of articles with particular content-type,
+that can be useful if it is not desired to have delays because of long PDF resources.
+The default html value for the particular content type can be provided and then used in order to define the actual content-type of the article
+
+.. code-block:: pycon
+
+    >>> from newspaper import Article
+    >>> pdf_defaults = {"application/pdf": "%PDF-",
+                      "application/x-pdf": "%PDF-",
+                      "application/x-bzpdf": "%PDF-",
+                      "application/x-gzpdf": "%PDF-"}
+    >>> pdf_article = Article(url='https://www.adobe.com/pdf/pdfs/ISO32000-1PublicPatentLicense.pdf',
+                                            ignored_content_types_defaults=pdf_defaults)
+    >>> pdf_article.download()
+    >>> print(pdf_article.html)
+    %PDF-
+
 There are endless possibilities on how we can manipulate and build articles.
 
 Downloading an Article

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -34,6 +34,7 @@ class Configuration(object):
         self.MAX_AUTHORS = 10  # num strings in list
         self.MAX_SUMMARY = 5000  # num of chars
         self.MAX_SUMMARY_SENT = 5  # num of sentences
+        self.EMPTY_PDF = "%PDF-"  # empty PDF constant
 
         # max number of urls we cache for each news source
         self.MAX_FILE_MEMO = 20000
@@ -73,6 +74,10 @@ class Configuration(object):
 
         self.thread_timeout_seconds = 1
 
+        self.ignored_content_types_defaults = {"application/pdf": self.EMPTY_PDF,
+                                               "application/x-pdf": self.EMPTY_PDF,
+                                               "application/x-bzpdf": self.EMPTY_PDF,
+                                               "application/x-gzpdf": self.EMPTY_PDF}
         # Set this to False if you want to recompute the categories
         # *every* time you build a `Source` object
         # TODO: Actually make this work

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -34,7 +34,6 @@ class Configuration(object):
         self.MAX_AUTHORS = 10  # num strings in list
         self.MAX_SUMMARY = 5000  # num of chars
         self.MAX_SUMMARY_SENT = 5  # num of sentences
-        self.EMPTY_PDF = "%PDF-"  # empty PDF constant
 
         # max number of urls we cache for each news source
         self.MAX_FILE_MEMO = 20000
@@ -73,11 +72,7 @@ class Configuration(object):
         self.verbose = False  # for debugging
 
         self.thread_timeout_seconds = 1
-
-        self.ignored_content_types_defaults = {"application/pdf": self.EMPTY_PDF,
-                                               "application/x-pdf": self.EMPTY_PDF,
-                                               "application/x-bzpdf": self.EMPTY_PDF,
-                                               "application/x-gzpdf": self.EMPTY_PDF}
+        self.ignored_content_types_defaults = {}
         # Set this to False if you want to recompute the categories
         # *every* time you build a `Source` object
         # TODO: Actually make this work

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -57,12 +57,12 @@ def get_html_2XX_only(url, config=None, response=None):
     headers = config.headers
 
     if response is not None:
-        return _get_html_from_response(response)
+        return _get_html_from_response(response, config)
 
     response = requests.get(
         url=url, **get_request_kwargs(timeout, useragent, proxies, headers))
 
-    html = _get_html_from_response(response)
+    html = _get_html_from_response(response, config)
 
     if config.http_success_only:
         # fail if HTTP sends a non 2XX response
@@ -71,7 +71,10 @@ def get_html_2XX_only(url, config=None, response=None):
     return html
 
 
-def _get_html_from_response(response):
+def _get_html_from_response(response, config=None):
+    for disabled_type in config.ignored_content_types_defaults:
+        if disabled_type in response.headers.get('content-type'):
+            return config.ignored_content_types_defaults[disabled_type]
     if response.encoding != FAIL_ENCODING:
         # return response as a unicode string
         html = response.text

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -71,7 +71,7 @@ def get_html_2XX_only(url, config=None, response=None):
     return html
 
 
-def _get_html_from_response(response, config=None):
+def _get_html_from_response(response, config):
     if response.headers.get('content-type') in config.ignored_content_types_defaults:
         return config.ignored_content_types_defaults[response.headers.get('content-type')]
     if response.encoding != FAIL_ENCODING:

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -72,9 +72,8 @@ def get_html_2XX_only(url, config=None, response=None):
 
 
 def _get_html_from_response(response, config=None):
-    for disabled_type in config.ignored_content_types_defaults:
-        if disabled_type == response.headers.get('content-type'):
-            return config.ignored_content_types_defaults[disabled_type]
+    if response.headers.get('content-type') in config.ignored_content_types_defaults:
+        return config.ignored_content_types_defaults[response.headers.get('content-type')]
     if response.encoding != FAIL_ENCODING:
         # return response as a unicode string
         html = response.text

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -73,7 +73,7 @@ def get_html_2XX_only(url, config=None, response=None):
 
 def _get_html_from_response(response, config=None):
     for disabled_type in config.ignored_content_types_defaults:
-        if disabled_type in response.headers.get('content-type'):
+        if disabled_type == response.headers.get('content-type'):
             return config.ignored_content_types_defaults[disabled_type]
     if response.encoding != FAIL_ENCODING:
         # return response as a unicode string

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -742,21 +742,19 @@ class TestDownloadPdf(unittest.TestCase):
     @print_test
     def test_article_pdf_ignoring(self):
         configuration = Configuration()
-        EMPTY_PDF = "%PDF-"  # empty PDF constant
-        configuration.ignored_content_types_defaults = {"application/pdf": EMPTY_PDF,
-                                               "application/x-pdf": EMPTY_PDF,
-                                               "application/x-bzpdf": EMPTY_PDF,
-                                               "application/x-gzpdf": EMPTY_PDF}
+        empty_pdf = "%PDF-"  # empty PDF constant
+        configuration.ignored_content_types_defaults = {"application/pdf": empty_pdf,
+                                               "application/x-pdf": empty_pdf,
+                                               "application/x-bzpdf": empty_pdf,
+                                               "application/x-gzpdf": empty_pdf}
         a = Article(url='http://www.technik-medien.at/ePaper_Download/'
                         'IoT4Industry+Business_2018-10-31_2018-03.pdf', config=configuration)
         a.download()
-        self.assertEqual('%PDF-', a.html)
+        self.assertEqual(empty_pdf, a.html)
 
     @print_test
     def test_article_pdf_fetching(self):
-        configuration = Configuration()
-        configuration.ignored_content_types_defaults = {}
-        a = Article(url='https://www.adobe.com/pdf/pdfs/ISO32000-1PublicPatentLicense.pdf', config=configuration)
+        a = Article(url='https://www.adobe.com/pdf/pdfs/ISO32000-1PublicPatentLicense.pdf')
         a.download()
         self.assertNotEqual('%PDF-', a.html)
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -737,6 +737,23 @@ class TestNewspaperLanguagesApi(unittest.TestCase):
         newspaper.languages()
 
 
+class TestDownloadPdf(unittest.TestCase):
+
+    @print_test
+    def test_article_pdf_ignoring(self):
+        a = Article(url='http://www.technik-medien.at/ePaper_Download/'
+                        'IoT4Industry+Business_2018-10-31_2018-03.pdf')
+        a.download()
+        self.assertEqual('%PDF-', a.html)
+
+    @print_test
+    def test_article_pdf_fetching(self):
+        configuration = Configuration()
+        configuration.ignored_content_types_defaults = {}
+        a = Article(url='https://www.adobe.com/pdf/pdfs/ISO32000-1PublicPatentLicense.pdf', config=configuration)
+        a.download()
+        self.assertNotEqual('%PDF-', a.html)
+
 if __name__ == '__main__':
     argv = list(sys.argv)
     if 'fulltext' in argv:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -741,14 +741,13 @@ class TestDownloadPdf(unittest.TestCase):
 
     @print_test
     def test_article_pdf_ignoring(self):
-        configuration = Configuration()
         empty_pdf = "%PDF-"  # empty PDF constant
-        configuration.ignored_content_types_defaults = {"application/pdf": empty_pdf,
-                                               "application/x-pdf": empty_pdf,
-                                               "application/x-bzpdf": empty_pdf,
-                                               "application/x-gzpdf": empty_pdf}
         a = Article(url='http://www.technik-medien.at/ePaper_Download/'
-                        'IoT4Industry+Business_2018-10-31_2018-03.pdf', config=configuration)
+                        'IoT4Industry+Business_2018-10-31_2018-03.pdf',
+                    ignored_content_types_defaults={"application/pdf": empty_pdf,
+                                                    "application/x-pdf": empty_pdf,
+                                                    "application/x-bzpdf": empty_pdf,
+                                                    "application/x-gzpdf": empty_pdf})
         a.download()
         self.assertEqual(empty_pdf, a.html)
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -741,8 +741,14 @@ class TestDownloadPdf(unittest.TestCase):
 
     @print_test
     def test_article_pdf_ignoring(self):
+        configuration = Configuration()
+        EMPTY_PDF = "%PDF-"  # empty PDF constant
+        configuration.ignored_content_types_defaults = {"application/pdf": EMPTY_PDF,
+                                               "application/x-pdf": EMPTY_PDF,
+                                               "application/x-bzpdf": EMPTY_PDF,
+                                               "application/x-gzpdf": EMPTY_PDF}
         a = Article(url='http://www.technik-medien.at/ePaper_Download/'
-                        'IoT4Industry+Business_2018-10-31_2018-03.pdf')
+                        'IoT4Industry+Business_2018-10-31_2018-03.pdf', config=configuration)
         a.download()
         self.assertEqual('%PDF-', a.html)
 


### PR DESCRIPTION
When I run the download of long pdf article it often get failed by timeout on my application side. 

Change: 
- PDFs are ignored by default
- It's possible to add other content types for the ignoring list
- It's possible to switch off this ignoring by passing configuration ignored_content_types_defaults value 
 