### PR TITLE
Add more tags in extractor to search for authors

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -146,9 +146,10 @@ class ContentExtractor(object):
                 found = self.parser.getElementsByTag(doc, attr=attr, value=val)
                 matches.extend(found)
 
+        TAGS = ['meta','div','iframe','a','span','section']
         for match in matches:
             content = ''
-            if match.tag == 'meta':
+            if match.tag in TAGS:
                 mm = match.xpath('@content')
                 if len(mm) > 0:
                     content = mm[0]


### PR DESCRIPTION
Hello @codelucas, I have made the changes you asked in my previous pull request ( 575 )

I am using the newspaper3k library for my project and I have noticed that it does not extract the list of authors from some websites. I have discovered a few tags which can contain the name of authors of articles. It would be really great if you could add those tags for searching authors.
