### PR TITLE
Adding MIME type to Article

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -193,8 +193,12 @@ class Article(object):
             parsed_url = urlparse(self.url)
             if parsed_url.scheme == "file":
                 html = self._parse_scheme_file(parsed_url.path)
+                # Hard code to text/html for now
+                mime_type = "text/html"
             else:
-                html = self._parse_scheme_http()
+                result = self._parse_scheme_http()
+                html = result.html
+                mime_type = result.mime_type
             if html is None:
                 log.debug('Download failed on URL %s because of %s' %
                           (self.url, self.download_exception_msg))
@@ -204,12 +208,12 @@ class Article(object):
             # For now, just add a literal MIME type if html is set
             mime_type = "text/html"
 
-
         if self.config.follow_meta_refresh:
             meta_refresh_url = extract_meta_refresh(html)
             if meta_refresh_url and recursion_counter < 1:
                 return self.download(
                     input_html=network.get_html(meta_refresh_url).html,
+                    mime_type=mime_type,
                     recursion_counter=recursion_counter + 1)
 
         self.set_html(html)

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -194,7 +194,7 @@ class Article(object):
             if parsed_url.scheme == "file":
                 html = self._parse_scheme_file(parsed_url.path)
                 # Hard code to text/html for now
-                mime_type = "text/html"
+                mime_type = None
             else:
                 result = self._parse_scheme_http()
                 html = result.html

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -68,7 +68,13 @@ def get_html_2XX_only(url, config=None, response=None):
         # fail if HTTP sends a non 2XX response
         response.raise_for_status()
 
-    return html
+    # Check to see if the Content-Type header exists
+    mime_type = None
+    if 'content-type' in response.headers:
+        mime_type = response.headers['content-type']
+
+    # return html
+    return ArticleResponseWrapper(html, mime_type)
 
 
 def _get_html_from_response(response, config):
@@ -112,6 +118,17 @@ class MRequest(object):
                 self.resp.raise_for_status()
         except requests.exceptions.RequestException as e:
             log.critical('[REQUEST FAILED] ' + str(e))
+
+class ArticleResponseWrapper(object):
+    """Wrapper for returning html and mime type from the various
+    download methods. This should be treated as a simple DTO and
+    not used directly, as the values will be populated on the
+    Article itself.
+    """
+    def __init__(self, html, mime_type):
+        self.html = html
+        self.mime_type = mime_type
+
 
 
 def multithread_request(urls, config=None):

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -71,7 +71,7 @@ def get_html_2XX_only(url, config=None, response=None):
     # Check to see if the Content-Type header exists
     mime_type = None
     if 'content-type' in response.headers:
-        mime_type = response.headers['content-type']
+        mime_type = response.headers.get('content-type').split(';')[0]
 
     # return html
     return ArticleResponseWrapper(html, mime_type)

--- a/newspaper/source.py
+++ b/newspaper/source.py
@@ -177,7 +177,7 @@ class Source(object):
     def download(self):
         """Downloads html of source
         """
-        self.html = network.get_html(self.url, self.config)
+        self.html = network.get_html(self.url, self.config).html
 
     def download_categories(self):
         """Download all category html, can use mthreading


### PR DESCRIPTION
This PR adds MIME type to the Article class from the server. For provided HTML content it defaults to `text/html`. Similar for the `file:///` loaded articles. The latter is not strictly a correct behavior, rather we should try to deduce based on some set of well-known file extensions or similar mechanism. However, decided to put up the PR for discussion. 😃 

@codelucas can you PTAL and comment? 

Fixes #576 