### PR TITLE
Added configuration of author name format preservation during content…

### DIFF
--- a/docs/user_guide/advanced.rst
+++ b/docs/user_guide/advanced.rst
@@ -202,6 +202,8 @@ Here is a full list of the configuration options:
 
 ``keep_article_html``, default False, "set to True if you want to preserve html of body text"
 
+``keep_authors_format``, default False, "set to True if you want to preserve format of author name (would not be converted to Title Case format)"
+
 ``http_success_only``, default True, "set to False to capture non 2XX responses as well"
 
 ``MIN_WORD_COUNT``, default 300, "num of word tokens in article text"

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -54,6 +54,10 @@ class Configuration(object):
         # You may keep the html of just the main article body
         self.keep_article_html = False
 
+        # You may keep the format of the author 
+        # name so it would not be titlecased
+        self.keep_authors_format = False
+
         # Fail for error responses (e.g. 404 page)
         self.http_success_only = True
 

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -88,7 +88,10 @@ class ContentExtractor(object):
                 if item.lower() in seen:
                     continue
                 seen[item.lower()] = 1
-                result.append(item.title())
+                if self.config.keep_authors_format:
+                    result.append(item)
+                else: 
+                    result.append(item.title())
             return result
 
         def parse_byline(search_str):


### PR DESCRIPTION
Added variable to Configuration class that allows preserving the original name writing. 

E.g. author of an article is **LEWIS JONES**, now library always converts it to **Lewis Jones**. 
But sometimes I need the initial version. So I think it would be good to have such a setting.