### PR TITLE
Fix xpath selector for extracting feeds

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -380,7 +380,7 @@ class ContentExtractor(object):
         """
         total_feed_urls = []
         for category in categories:
-            kwargs = {'attr': 'type', 'value': 'application\/rss\+xml'}
+            kwargs = {'attr': 'type', 'value': 'application/rss+xml'}
             feed_elements = self.parser.getElementsByTag(
                 category.doc, **kwargs)
             feed_urls = [e.get('href') for e in feed_elements if e.get('href')]

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -26,6 +26,7 @@ URLS_FILE = os.path.join(TEST_DIR, 'data', 'fulltext_url_list.txt')
 import newspaper
 from newspaper import Article, fulltext, Source, ArticleException, news_pool
 from newspaper.article import ArticleDownloadState
+from newspaper.source import Category
 from newspaper.configuration import Configuration
 from newspaper.urls import get_domain
 
@@ -521,6 +522,27 @@ class SourceTestCase(unittest.TestCase):
         s.set_categories()
         self.assertCountEqual(saved_urls, s.category_urls())
 
+
+class FeedTestCase(unittest.TestCase):
+    @print_test
+    def test_feed_extraction(self):
+        """Test that feeds are matched properly
+        """
+        url = 'http://theatlantic.com'
+        html = mock_resource_with('theatlantic.com1', 'html')
+        s = Source(url, memoize_articles=False)
+        s.html = html
+        s.parse()
+        # mock in categories containing only homepage
+        #s.set_categories()
+        category = Category(url=url)
+        category.html = html
+        category.doc = s.doc
+        s.categories = [category,]
+        #s.parse_categories()
+        s.set_feeds()
+        self.assertEqual(len(s.feeds), 3)
+ 
 
 class UrlTestCase(unittest.TestCase):
     @print_test


### PR DESCRIPTION
For https://github.com/codelucas/newspaper/issues/731

Also added a test case based on a mock already included in the test data fixtures.

Adapting the test code from the issue I created:

```
import newspaper
  
def debug_source(url):
  source = newspaper.build(
    url,
    download_images = False,
    fetch_images = False,
  )
  print(url)
  print('feeds:', [f.url for f in source.feeds])


if __name__ == '__main__':
  debug_source('https://www.npr.org/')
  debug_source('https://techcrunch.com')
  debug_source('https://vox.com')
```

The new output is now:
```
$ python test_np.py 
https://www.npr.org/
feeds: ['https://www.npr.org/rss/rss.php?id=718730324', 'https://www.npr.org/rss/rss.php?id=1002', 'https://www.npr.org/rss/rss.php?id=688409791', 'https://www.npr.org/rss/rss.php?id=690263240', 'https://www.npr.org/rss/rss.php?id=1032', 'https://www.npr.org/rss/rss.php?id=1001', 'https://www.npr.org/rss/rss.php?id=35', 'https://www.npr.org/rss/rss.php?id=750001', 'https://www.npr.org/rss/rss.php?id=1008', 'https://www.npr.org/rss/rss.php?id=3', 'https://www.npr.org/rss/rss.php?id=376751684', 'https://www.npr.org/rss/rss.php?id=1039', 'https://www.npr.org/rss/rss.php?id=2', 'https://www.npr.org/rss/rss.php?id=750005', 'https://www.npr.org/rss/rss.php?id=750002']
https://techcrunch.com
feeds: ['https://techcrunch.com/comments/feed/', 'https://techcrunch.com/feed/']
https://vox.com
feeds: ['https://www.vox.com/rss/videos/index.xml', 'https://www.vox.com/rss/technology/index.xml', 'https://vox.com/rss/index.xml', 'https://www.vox.com/rss/recode/index.xml', 'https://www.vox.com/rss/identities/index.xml', 'https://www.vox.com/rss/culture/index.xml', 'https://www.vox.com/rss/first-person/index.xml', 'https://www.vox.com/rss/front-page/index.xml', 'https://www.vox.com/rss/world/index.xml', 'https://www.vox.com/rss/explainers/index.xml']
```