### PR TITLE
OutputFormatter - don't remove `img` tags

### DIFF
--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -135,7 +135,10 @@ class OutputFormatter(object):
                     and len(self.parser.getElementsByTag(
                         el, tag='object')) == 0 \
                     and len(self.parser.getElementsByTag(
-                        el, tag='embed')) == 0:
+                        el, tag='embed')) == 0 \
+                    and len(self.parser.getElementsByTag(
+                        el, tag='img')) == 0 \
+                    and tag not in {'img', }:
                 self.parser.remove(el)
 
     def remove_trailing_media_div(self):


### PR DESCRIPTION
I was working on a small project it matters to keep the original structure of an article.
And as I experienced so far, keeping `img` html tags in that way doesn't affect parsing efficiency.