### PR TITLE
Problem with memoize_articles=False and cacheing

### DIFF
--- a/newspaper/source.py
+++ b/newspaper/source.py
@@ -125,7 +125,10 @@ class Source(object):
         return self.extractor.get_category_urls(self.url, self.doc)
 
     def set_categories(self):
-        urls = self._get_category_urls(self.domain)
+        if self.config.memoize_articles:
+            urls = self._get_category_urls(self.domain)
+        else:
+            urls = self.extractor.get_category_urls(self.url, self.doc)
         self.categories = [Category(url=url) for url in urls]
 
     def set_feeds(self):

--- a/newspaper/source.py
+++ b/newspaper/source.py
@@ -123,8 +123,10 @@ class Source(object):
         We are caching categories for 1 day.
         """
         return self.extractor.get_category_urls(self.url, self.doc)
-
+    
     def set_categories(self):
+        # changed code:
+        # only use the private cached function if memoize_articles is False
         if self.config.memoize_articles:
             urls = self._get_category_urls(self.domain)
         else:


### PR DESCRIPTION
Setting memoize_articles to False still caches articles. The docs say that setting it to False shouldn't cache anything.

This can cause problems when scraping a site such as wayback machine. Multiple sites would have the same web.archive prefix and so the cache would consider them to have the same feeds. So grabbing another source would use the previous source's cached feed.

Setting memoize articles to False should prevent this, but cache is still being set.

Maybe just some code like this in source would allow memoize_articles=False to do this: