### PR TITLE
Fix nlp.keywords() return values

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -378,7 +378,10 @@ class Article(object):
         nlp.load_stopwords(self.config.get_language())
         text_keyws = list(nlp.keywords(self.text).keys())
         title_keyws = list(nlp.keywords(self.title).keys())
-        keyws = list(set(title_keyws + text_keyws))
+        keyws = set(title_keyws)
+        while len(keyws) < nlp.NUM_KEYWORDS and text_keyws:
+            keyws.add(text_keyws.pop(0))
+        keyws = list(keyws)
         self.set_keywords(keyws)
 
         max_sents = self.config.MAX_SUMMARY_SENT

--- a/newspaper/nlp.py
+++ b/newspaper/nlp.py
@@ -19,6 +19,9 @@ ideal = 20.0
 
 stopwords = set()
 
+NUM_KEYWORDS = 10
+
+
 def load_stopwords(language):
     """ 
     Loads language-specific stopwords for keyword selection
@@ -122,7 +125,6 @@ def keywords(text):
     sorts them in reverse natural order (so descending) by number of
     occurrences.
     """
-    NUM_KEYWORDS = 10
     text = split_words(text)
     # of words before removing blacklist words
     if text:


### PR DESCRIPTION
Resolves #311 by replacing:
```
keyws = list(set(title_keyws + text_keyws))
```
with
```
keyws = set(title_keyws)
while len(keyws) < nlp.NUM_KEYWORDS and text_keyws:
     # add most frequent keyws first
     keyws.add(text_keyws.pop(0))
keyws = list(keyws)
```
nlp.NUM_KEYWORS is currently a local variable in the keywords function defined in nlp.py. Since I need it in this snippet I promote it to a global variable and define it at the top of nlp.py.