### PR TITLE
Added links scraping functionality to parser

### DIFF
--- a/newspaper/api.py
+++ b/newspaper/api.py
@@ -89,5 +89,5 @@ def fulltext(html, language='en'):
 
     top_node = extractor.calculate_best_node(doc)
     top_node = extractor.post_cleanup(top_node)
-    text, article_html = output_formatter.get_formatted(top_node)
+    text, article_html, links = output_formatter.get_formatted(top_node)
     return text

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -111,6 +111,9 @@ class Article(object):
         # The HTML of this article's main node (most important part)
         self.article_html = ''
 
+        # List of links found in article
+        self.links = []
+
         # Keep state for downloads and parsing
         self.is_parsed = False
         self.download_state = ArticleDownloadState.NOT_STARTED
@@ -278,10 +281,11 @@ class Article(object):
             self.top_node = self.extractor.post_cleanup(self.top_node)
             self.clean_top_node = copy.deepcopy(self.top_node)
 
-            text, article_html = output_formatter.get_formatted(
+            text, article_html, links = output_formatter.get_formatted(
                 self.top_node)
             self.set_article_html(article_html)
             self.set_text(text)
+            self.set_links(links)
 
         self.fetch_images()
 
@@ -451,6 +455,10 @@ class Article(object):
         text = text[:self.config.MAX_TEXT]
         if text:
             self.text = text
+
+    def set_links(self, links):
+        if links:
+            self.links = links
 
     def set_html(self, html):
         """Encode HTML before setting it

--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -50,14 +50,14 @@ class OutputFormatter(object):
         if self.config.keep_article_html:
             html = self.convert_to_html()
 
-        # self.links_to_text()
         self.add_newline_to_br()
         self.add_newline_to_li()
         self.replace_with_text()
         self.remove_empty_tags()
         self.remove_trailing_media_div()
-        text = self.convert_to_text()
         links = self.convert_to_links()
+        self.links_to_text()
+        text = self.convert_to_text()
         # print(self.parser.nodeToString(self.get_top_node()))
         return (text, html, links)
 
@@ -79,16 +79,10 @@ class OutputFormatter(object):
 
     def convert_to_links(self):
         links = []
-        for i, node in enumerate(list(self.get_top_node())):
-            try:
-                print(i)
-                for x in node.iter():
-                    if x.tag == 'a':
-                        links += [dict(x.items())["href"]]
-                txt = self.parser.getText(node)
-            except ValueError as err:  # lxml error
-                log.info('%s ignoring lxml node error: %s', __title__, err)
-                txt = None
+        for node in list(self.get_top_node()):
+            for x in node.iter():
+                if x.tag == 'a':
+                    links += [dict(x.items())["href"]]
 
         return links
 

--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -50,15 +50,16 @@ class OutputFormatter(object):
         if self.config.keep_article_html:
             html = self.convert_to_html()
 
-        self.links_to_text()
+        # self.links_to_text()
         self.add_newline_to_br()
         self.add_newline_to_li()
         self.replace_with_text()
         self.remove_empty_tags()
         self.remove_trailing_media_div()
         text = self.convert_to_text()
+        links = self.convert_to_links()
         # print(self.parser.nodeToString(self.get_top_node()))
-        return (text, html)
+        return (text, html, links)
 
     def convert_to_text(self):
         txts = []
@@ -75,6 +76,21 @@ class OutputFormatter(object):
                 txt_lis = [n.strip(' ') for n in txt_lis]
                 txts.extend(txt_lis)
         return '\n\n'.join(txts)
+
+    def convert_to_links(self):
+        links = []
+        for i, node in enumerate(list(self.get_top_node())):
+            try:
+                print(i)
+                for x in node.iter():
+                    if x.tag == 'a':
+                        links += [dict(x.items())["href"]]
+                txt = self.parser.getText(node)
+            except ValueError as err:  # lxml error
+                log.info('%s ignoring lxml node error: %s', __title__, err)
+                txt = None
+
+        return links
 
     def convert_to_html(self):
         cleaned_node = self.parser.clean_article_html(self.get_top_node())

--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -83,7 +83,6 @@ class OutputFormatter(object):
             for x in node.iter():
                 if x.tag == 'a':
                     links += [dict(x.items())["href"]]
-
         return links
 
     def convert_to_html(self):


### PR DESCRIPTION
I downloaded this package looking for something that could parse links within the main article, but noticed the functionality wasn't included, so I added some small changes so the Article object also collects a list of links when parse() is called.

Users will now by able to access a list of links in the article with `article.links` after calling `article.parse()`.