### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/newspaper/utils.py
+++ b/newspaper/utils.py
@@ -141,7 +141,7 @@ def timelimit(timeout):
                         self.error = sys.exc_info()
             c = Dispatch()
             c.join(timeout)
-            if c.isAlive():
+            if c.is_alive():
                 raise TimeoutError()
             if c.error:
                 raise c.error[0](c.error[1])


### PR DESCRIPTION
Fixes #804 