### PR TITLE
Update in PUBLISH_DATE_TAGS for date extraction

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -206,6 +206,8 @@ class ContentExtractor(object):
              'content': 'datetime'},
             {'attribute': 'property', 'value': 'og:published_time',
              'content': 'content'},
+            {'attribute': 'property', 'value': 'og:regDate',
+             'content': 'content'},
             {'attribute': 'name', 'value': 'article_date_original',
              'content': 'content'},
             {'attribute': 'name', 'value': 'publication_date',


### PR DESCRIPTION
Korean web portal "Daum" another attribute in <meta> for the published datetime.

Link: https://news.v.daum.net/v/20201207190232276

![Screenshot from 2020-12-07 21-53-49](https://user-images.githubusercontent.com/20375234/101353573-26805200-38d7-11eb-9756-8bb141dc1a3c.png)
