### PR TITLE
Add article to node search tags

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -1014,7 +1014,7 @@ class ContentExtractor(object):
         on like paragraphs and tables
         """
         nodes_to_check = []
-        for tag in ['p', 'pre', 'td']:
+        for tag in ['p', 'pre', 'td', 'article']:
             items = self.parser.getElementsByTag(doc, tag=tag)
             nodes_to_check += items
         return nodes_to_check


### PR DESCRIPTION
* The <article> tag often denotes exactly where the article begins and ends in HTML5.

I noticed the wrong text was being pulled from articles on the bbc.co.uk. This includes whole articles rather than focusing on good paragraphs or table rows.