### PR TITLE
Fix concatenating sentence parts separated with newlines

### DIFF
--- a/newspaper/nlp.py
+++ b/newspaper/nlp.py
@@ -157,7 +157,7 @@ def split_sentences(text):
     tokenizer = nltk.data.load('tokenizers/punkt/english.pickle')
 
     sentences = tokenizer.tokenize(text)
-    sentences = [x.replace('\n', '') for x in sentences if len(x) > 10]
+    sentences = [re.sub('[\n ]+', ' ', x) for x in sentences if len(x) > 10]
     return sentences
 
 


### PR DESCRIPTION
The text content of newspapers seems to be returned as paragraphs separated by two newlines. When doing nlp on this, the tokenizer sometimes thinks a sentence spans across two paragraphs, returning a sentence looking like `'first sentence\n\nsecond sentence'`, which means this part of the code would concatenate the words sentence and second, returning `'first sentencesecond sentence'`. This change is meant to fix that, by replacing any run of multiple spaces or newlines by one space.

Another solution would be to first split on double newlines and processing the content of that separately before concatenating again, but this seemed like it would change the least