### PR TITLE
Include all nodes with text

### DIFF
--- a/newspaper/api.py
+++ b/newspaper/api.py
@@ -82,12 +82,12 @@ def fulltext(html, language='en'):
 
     extractor = ContentExtractor(config)
     document_cleaner = DocumentCleaner(config)
-    output_formatter = OutputFormatter(config)
+    output_formatter = OutputFormatter(config, extractor)
 
     doc = config.get_parser().fromstring(html)
     doc = document_cleaner.clean(doc)
 
-    top_node = extractor.calculate_best_node(doc)
+    top_node, extra_nodes = extractor.calculate_best_node(doc)
     top_node = extractor.post_cleanup(top_node)
-    text, article_html = output_formatter.get_formatted(top_node)
+    text, article_html = output_formatter.get_formatted(top_node, extra_nodes)
     return text

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -224,7 +224,7 @@ class Article(object):
         self.link_hash = parse_candidate.link_hash  # MD5
 
         document_cleaner = DocumentCleaner(self.config)
-        output_formatter = OutputFormatter(self.config)
+        output_formatter = OutputFormatter(self.config, self.extractor)
 
         title = self.extractor.get_title(self.clean_doc)
         self.set_title(title)
@@ -270,7 +270,7 @@ class Article(object):
         # Before any computations on the body, clean DOM object
         self.doc = document_cleaner.clean(self.doc)
 
-        self.top_node = self.extractor.calculate_best_node(self.doc)
+        self.top_node, extra_nodes = self.extractor.calculate_best_node(self.doc)
         if self.top_node is not None:
             video_extractor = VideoExtractor(self.config, self.top_node)
             self.set_movies(video_extractor.get_videos())
@@ -278,8 +278,7 @@ class Article(object):
             self.top_node = self.extractor.post_cleanup(self.top_node)
             self.clean_top_node = copy.deepcopy(self.top_node)
 
-            text, article_html = output_formatter.get_formatted(
-                self.top_node)
+            text, article_html = output_formatter.get_formatted(self.top_node, extra_nodes)
             self.set_article_html(article_html)
             self.set_text(text)
 

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -1036,7 +1036,7 @@ class ContentExtractor(object):
         on like paragraphs and tables
         """
         nodes_to_check = []
-        for tag in ['p', 'pre', 'td']:
+        for tag in ['p', 'pre', 'strong', 'td']:
             items = self.parser.getElementsByTag(doc, tag=tag)
             nodes_to_check += items
         return nodes_to_check

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -1036,7 +1036,7 @@ class ContentExtractor(object):
         on like paragraphs and tables
         """
         nodes_to_check = []
-        for tag in ['p', 'pre', 'strong', 'td']:
+        for tag in ['p', 'pre', 'td']:
             items = self.parser.getElementsByTag(doc, tag=tag)
             nodes_to_check += items
         return nodes_to_check

--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -88,7 +88,7 @@ class OutputFormatter(object):
         # For each additional node we have...
         for extra in extra_nodes:
             # if its text is not in the final text and it does not have a high link density...
-            if extra.text is not None and extra.text in candidate_text \
+            if extra.text is not None and extra.text not in candidate_text \
                     and not self.extractor.is_highlink_density(extra):
                 # Parse any hyperlinks and include in final text
                 self.parser.stripTags(extra, 'a')

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -683,8 +683,14 @@ class MultiLanguageTestCase(unittest.TestCase):
             self.assertEqual(expected, tested)
         except AssertionError as e:
             # If this failed, check the expected text is contained in the generated text we are testing
-            # Warn the user this test case hasn't passed as expected but the main article text is covered
-            if expected in tested:
+            expected_split = expected.split('\n\n')
+            tested_split = tested.split('\n\n')
+            # Every sentence that's in both the expected text and generated text
+            matches = set(expected_split).intersection(tested_split)
+            # For the expected text to be included in the generated text, all its elements must be in the intersection
+            # with the generated text
+            if len(matches) == len(expected_split):
+                # Warn the user this test case hasn't passed as expected but the main article text is covered
                 warnings.warn('Expected text and parsed article text do not match. Expected text is still covered '
                               '(i.e. is within) parsed article text. Original error: ' + str(e))
             else:  # else raise the original AssertionError as this test case should fail


### PR DESCRIPTION
Closes #363

- To tackle missing article paragraphs, this suggestion considers any node with text to be included in the final text attribute of an article instance
- Test cases pass with a warning where extra text has been found (i.e. equal-text asserts fail) but main article text has been found within parsed article text

Edit - found more missing text when using this [url](https://www.crowdstrike.com/blog/bears-midst-intrusion-democratic-national-committee/). This is because there are < li >s not being gathered. Plus the < table > at the bottom of the page didn't translate to text well. As these are further fixes (that may break how this PR fixes for other urls), my fixes for this are in jecarr#1