### PR TITLE
set daemon attribute directly instead of calling setDaemon function to clear deprecation warning in python3.10

### DIFF
--- a/newspaper/utils.py
+++ b/newspaper/utils.py
@@ -131,7 +131,7 @@ def timelimit(timeout):
                     self.result = None
                     self.error = None
 
-                    self.setDaemon(True)
+                    self.daemon = True
                     self.start()
 
                 def run(self):


### PR DESCRIPTION
Fixes #883 