### PR TITLE
Replace os.listdir by os.scandir in utils.get_available_languages

### DIFF
--- a/newspaper/utils.py
+++ b/newspaper/utils.py
@@ -343,11 +343,12 @@ def get_useragent():
 def get_available_languages():
     """Returns a list of available languages and their 2 char input codes
     """
-    stopword_files = os.listdir(os.path.join(settings.STOPWORDS_DIR))
-    two_dig_codes = [f.split('-')[1].split('.')[0] for f in stopword_files]
-    for d in two_dig_codes:
-        assert len(d) == 2
-    two_dig_codes.sort()
+    two_dig_codes = []
+    with os.scandir(settings.STOPWORDS_DIR) as stopwords_files:
+        for x in stopwords_files:
+            d = stopwords_files.__next__().name.split('-')[1].split('.')[0]
+            assert len(d) == 2
+            two_dig_codes.append(d)
     return two_dig_codes
 
 


### PR DESCRIPTION
I ran into an os.error (Too many open files) while parsing files on a debian machine :
```
  File "/home/blablah/.cache/pypoetry/virtualenvs/adoc-H6ni72Z6-py3.10/lib/python3.10/site-packages/newspaper/article.py", line 214, in parse
  File "/home/blablah/.cache/pypoetry/virtualenvs/adoc-H6ni72Z6-py3.10/lib/python3.10/site-packages/newspaper/article.py", line 495, in set_meta_language
  File "/home/blablah/.cache/pypoetry/virtualenvs/adoc-H6ni72Z6-py3.10/lib/python3.10/site-packages/newspaper/utils.py", line 346, in get_available_languages
OSError: [Errno 24] Too many open files: '/home/blablah/.cache/pypoetry/virtualenvs/adoc-H6ni72Z6-py3.10/lib/python3.10/site-packages/newspaper/resources/text'

```

Using `help` on os.listdir returns : _"[...] On some platforms, path may also be specified as an open file descriptor; the file descriptor must refer to a directory. [...]"_

The [documentation](https://docs.python.org/3/library/os.html#os.listdir) also states that _"[t]he scandir() function returns directory entries along with file attribute information, giving better performance for many common use cases."_.

I ran a benchmark with timeit between the old code and the new one ; they are pretty much the same (ie. 67.3 µs ± 15.6 µs and 64.2 µs ± 12.8 µs resp.).

I'm not totally sure why os is trying to open files while using the listdir command, but switching to scandir should fix that behaviour (according to the documentation...).
to fix the exception.