### PR TITLE
fix itemprop containing articleBody

### DIFF
--- a/newspaper/cleaners.py
+++ b/newspaper/cleaners.py
@@ -47,7 +47,7 @@ class DocumentCleaner(object):
             .create("\n", "\n\n")\
             .append("\t")\
             .append("^\\s+$")
-        self.contains_article = './/article|.//*[@id="article"]|.//*[@itemprop="articleBody"]'
+        self.contains_article = './/article|.//*[@id="article"]|.//*[contains(@itemprop,"articleBody")]'
 
     def clean(self, doc_to_clean):
         """Remove chunks of the DOM as specified


### PR DESCRIPTION
If itemprop is not exactly == "articleBody" the node was "cleaned"

for instance itemprop="description articleBody" would be cleaned.  Blogspot / Blogger for instance uses this itemprop