### PR TITLE
fix(sec): upgrade requests to 2.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ Pillow>=3.3.0
 pythainlp>=1.7.2
 python-dateutil>=2.5.3
 PyYAML>=3.11
-requests>=2.10.0
+requests>=2.20
 tinysegmenter==0.3  # TODO(codelucas): Investigate making this >=0.3
 tldextract>=2.0.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in requests 2.10.0
- [CVE-2018-18074](https://www.oscs1024.com/hd/CVE-2018-18074)


### What did I do？
Upgrade requests from 2.10.0 to 2.20 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS