### PR TITLE
Update download_corpora.py - add 'punkt_tab'

### DIFF
--- a/download_corpora.py
+++ b/download_corpora.py
@@ -8,6 +8,7 @@ import nltk
 REQUIRED_CORPORA = [
     'brown',  # Required for FastNPExtractor
     'punkt',  # Required for WordTokenizer
+    'punkt_tab',
     'maxent_treebank_pos_tagger',  # Required for NLTKTagger
     'movie_reviews',  # Required for NaiveBayesAnalyzer
     'wordnet',  # Required for lemmatization and Wordnet


### PR DESCRIPTION
I noticed that it was throwing error for not finding "punkt_tab" in corpora, either in Windows or Docker.

Adding the following code helped, but devs may not notice it.

```
import nltk
nltk.download('punkt_tab')
```
