### PR TITLE
Also require lxml-html-clean>=0.4.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ feedfinder2>=0.0.4
 feedparser>=5.2.1
 jieba3k>=0.35.1
 lxml>=3.6.0
+lxml-html-clean>=0.4.2
 nltk>=3.2.1
 Pillow>=3.3.0
 pythainlp>=1.7.2


### PR DESCRIPTION
Why? As mentioned in https://github.com/codelucas/newspaper/issues/972, `lxml>=5.2` no longer provides `lxml.html.clean`. The same functionality is now provided by `lxml-html-clean`.

We only need a dependency change, as lxml still provides backward compatibility when `lxml-html-clean` is already installed.

Fixes #1007.