### PR TITLE
fix: handle punkt_tab fallback in split_sentences for NLTK >= 3.9

### DIFF
--- a/download_corpora.py
+++ b/download_corpora.py
@@ -8,6 +8,7 @@ import nltk
 REQUIRED_CORPORA = [
     'brown',  # Required for FastNPExtractor
     'punkt',  # Required for WordTokenizer
+    'punkt_tab',  # Required for WordTokenizer (NLTK >= 3.9)
     'maxent_treebank_pos_tagger',  # Required for NLTKTagger
     'movie_reviews',  # Required for NaiveBayesAnalyzer
     'wordnet',  # Required for lemmatization and Wordnet

--- a/newspaper/nlp.py
+++ b/newspaper/nlp.py
@@ -154,7 +154,10 @@ def split_sentences(text):
     """Split a large string into sentences
     """
     import nltk.data
-    tokenizer = nltk.data.load('tokenizers/punkt/english.pickle')
+    try:
+        tokenizer = nltk.data.load('tokenizers/punkt/english.pickle')
+    except LookupError:
+        tokenizer = nltk.data.load('tokenizers/punkt_tab/english')
 
     sentences = tokenizer.tokenize(text)
     sentences = [x.replace('\n', '') for x in sentences if len(x) > 10]


### PR DESCRIPTION
Fixes #1017

NLTK 3.9 moved the default punkt tokenizer from `tokenizers/punkt/english.pickle` to `tokenizers/punkt_tab/english`. On a fresh install with NLTK >= 3.9 only `punkt_tab` is downloaded, so calling `split_sentences()` raises a `LookupError` even when NLTK is properly installed.

**What this changes:**

1. `newspaper/nlp.py` - `split_sentences()` now tries the old path first and falls back to `punkt_tab` if not found. Works with both old and new NLTK versions.
2. `download_corpora.py` - adds `punkt_tab` to `REQUIRED_CORPORA` so it gets downloaded alongside `punkt`.

PR #1006 already adds `punkt_tab` to the download list, but the runtime crash in `nlp.py` still happens if only `punkt_tab` is available. This fixes both.