### PR TITLE
fix(date): recover publication dates the URL and JSON-LD already state

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -213,18 +213,21 @@ class Article(object):
         self.throw_if_not_downloaded_verbose()
 
         self.doc = self.config.get_parser().fromstring(self.html)
-        self.clean_doc = copy.deepcopy(self.doc)
 
         if self.doc is None:
             # `parse` call failed, return nothing
             return
 
+        document_cleaner = DocumentCleaner(self.config)
+        output_formatter = OutputFormatter(self.config)
+
+        self.clean_doc = copy.deepcopy(self.doc)
+        # Before any computations on the body, clean DOM object
+        self.clean_doc = document_cleaner.clean(self.clean_doc)
+
         # TODO: Fix this, sync in our fix_url() method
         parse_candidate = self.get_parse_candidate()
         self.link_hash = parse_candidate.link_hash  # MD5
-
-        document_cleaner = DocumentCleaner(self.config)
-        output_formatter = OutputFormatter(self.config)
 
         title = self.extractor.get_title(self.clean_doc)
         self.set_title(title)
@@ -266,9 +269,6 @@ class Article(object):
         self.publish_date = self.extractor.get_publishing_date(
             self.url,
             self.clean_doc)
-
-        # Before any computations on the body, clean DOM object
-        self.doc = document_cleaner.clean(self.doc)
 
         self.top_node = self.extractor.calculate_best_node(self.doc)
         if self.top_node is not None:

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -275,8 +275,8 @@ class Article(object):
             video_extractor = VideoExtractor(self.config, self.top_node)
             self.set_movies(video_extractor.get_videos())
 
-            self.top_node = self.extractor.post_cleanup(self.top_node)
             self.clean_top_node = copy.deepcopy(self.top_node)
+            self.clean_top_node = self.extractor.post_cleanup(self.clean_top_node)
 
             text, article_html = output_formatter.get_formatted(
                 self.top_node)

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -271,6 +271,8 @@ class Article(object):
             self.clean_doc)
 
         self.top_node = self.extractor.calculate_best_node(self.doc)
+        if self.top_node is None:
+            self.top_node = self.extractor.calculate_best_node(self.clean_doc)
         if self.top_node is not None:
             video_extractor = VideoExtractor(self.config, self.top_node)
             self.set_movies(video_extractor.get_videos())

--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -273,6 +273,14 @@ class Article(object):
         self.top_node = self.extractor.calculate_best_node(self.doc)
         if self.top_node is None:
             self.top_node = self.extractor.calculate_best_node(self.clean_doc)
+        if self.top_node is None:
+            self.top_node = self.extractor.parser.getElementById(self.doc, 'content')
+        if self.top_node is None:
+            for tag in ['article', 'main']:
+                nodes = self.extractor.parser.getElementsByTag(self.doc, tag=tag)
+                if len(nodes) > 0:
+                    self.top_node = nodes[0]
+                    break
         if self.top_node is not None:
             video_extractor = VideoExtractor(self.config, self.top_node)
             self.set_movies(video_extractor.get_videos())

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -57,6 +57,9 @@ class Configuration(object):
         # Fail for error responses (e.g. 404 page)
         self.http_success_only = True
 
+        # Allow redirects (enabled by default)
+        self.allow_redirects = True
+
         # English is the fallback
         self._language = 'en'
 

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -60,6 +60,7 @@ class Configuration(object):
         # Allow redirects (enabled by default)
         self.allow_redirects = True
 
+        self.ignored_images_suffix_list = []
         # English is the fallback
         self._language = 'en'
 

--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -72,6 +72,7 @@ class Configuration(object):
         self.request_timeout = 7
         self.proxies = {}
         self.number_threads = 10
+        self.verify_ssl_cert = True
 
         self.verbose = False  # for debugging
 

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -584,7 +584,7 @@ class ContentExtractor(object):
                 for img_tag in img_tags if img_tag.get('src')]
         img_links = set([urljoin(article_url, url)
                          for url in urls])
-        img_links = [x for x in img_links if not self.image_is_ignored(x)]
+        img_links = set([x for x in img_links if not self.image_is_ignored(x)])
         return img_links
 
     def get_first_img_url(self, article_url, top_node):

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -1017,6 +1017,10 @@ class ContentExtractor(object):
         for tag in ['p', 'pre', 'td', 'ol', 'ul']:
             items = self.parser.getElementsByTag(doc, tag=tag)
             nodes_to_check += items
+        for tag in ['section']:
+            items = self.parser.getElementsByTag(doc, tag=tag)
+            if len(items) > 1:
+                nodes_to_check = items
         return nodes_to_check
 
     def is_table_and_no_para_exist(self, e):

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -473,7 +473,7 @@ class ContentExtractor(object):
         return ''
 
     def image_is_ignored(self, image):
-        return len([True for x in self.config.ignored_images_suffix_list if image and self.match_image(x, os.path.basename(image))]) > 0
+        return any([True for x in self.config.ignored_images_suffix_list if image and image != '' and self.match_image(x, os.path.basename(image))])
 
     def match_image(self, pattern, image):
         return re.search(pattern, image) is not None
@@ -584,6 +584,7 @@ class ContentExtractor(object):
                 for img_tag in img_tags if img_tag.get('src')]
         img_links = set([urljoin(article_url, url)
                          for url in urls])
+        img_links = [x for x in img_links if not self.image_is_ignored(x)]
         return img_links
 
     def get_first_img_url(self, article_url, top_node):

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -1014,7 +1014,7 @@ class ContentExtractor(object):
         on like paragraphs and tables
         """
         nodes_to_check = []
-        for tag in ['p', 'pre', 'td']:
+        for tag in ['p', 'pre', 'td', 'ol', 'ul']:
             items = self.parser.getElementsByTag(doc, tag=tag)
             nodes_to_check += items
         return nodes_to_check

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -1015,7 +1015,7 @@ class ContentExtractor(object):
         """
         nodes_to_check = []
         articles = self.parser.getElementsByTag(doc, tag='article')
-        if len(articles) > 0:
+        if len(articles) > 0 and self.get_meta_site_name(doc) == 'Medium':
             # Specific heuristic for Medium articles
             sections = self.parser.getElementsByTag(articles[0], tag='section')
             if len(sections) > 1:

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -1014,13 +1014,16 @@ class ContentExtractor(object):
         on like paragraphs and tables
         """
         nodes_to_check = []
-        for tag in ['p', 'pre', 'td', 'ol', 'ul']:
-            items = self.parser.getElementsByTag(doc, tag=tag)
-            nodes_to_check += items
-        for tag in ['section']:
-            items = self.parser.getElementsByTag(doc, tag=tag)
-            if len(items) > 1:
-                nodes_to_check = items
+        articles = self.parser.getElementsByTag(doc, tag='article')
+        if len(articles) > 0:
+            # Specific heuristic for Medium articles
+            sections = self.parser.getElementsByTag(articles[0], tag='section')
+            if len(sections) > 1:
+                nodes_to_check = sections
+        if len(nodes_to_check) == 0:
+            for tag in ['p', 'pre', 'td', 'ol', 'ul']:
+                items = self.parser.getElementsByTag(doc, tag=tag)
+                nodes_to_check += items
         return nodes_to_check
 
     def is_table_and_no_para_exist(self, e):

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -254,12 +254,19 @@ class ContentExtractor(object):
         """
         title = ''
         title_element = self.parser.getElementsByTag(doc, tag='title')
-        # no title found
-        if title_element is None or len(title_element) == 0:
-            return title
+        title_text_fb = (
+            self.get_meta_content(doc, 'meta[property="og:title"]') or
+            self.get_meta_content(doc, 'meta[name="og:title"]') or ''
+        )
 
-        # title elem found
-        title_text = self.parser.getText(title_element[0])
+        # no title found, fallback to og:title
+        if title_element is None or len(title_element) == 0:
+            title_text = title_text_fb
+            if not title_text:
+                return title
+        else:
+            # title elem found
+            title_text = self.parser.getText(title_element[0])
         used_delimeter = False
 
         # title from h1
@@ -280,11 +287,6 @@ class ContentExtractor(object):
                 title_text_h1 = ''
             # clean double spaces
             title_text_h1 = ' '.join([x for x in title_text_h1.split() if x])
-
-        # title from og:title
-        title_text_fb = (
-        self.get_meta_content(doc, 'meta[property="og:title"]') or
-        self.get_meta_content(doc, 'meta[name="og:title"]') or '')
 
         # create filtered versions of title_text, title_text_h1, title_text_fb
         # for finer comparison

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -235,6 +235,24 @@ class ContentExtractor(object):
 
         return None
 
+    def _choose_title_candidate(self, candidates, og_title):
+        """Pick the best <title> when a document has more than one.
+
+        Prefer a candidate whose filtered text contains the og:title (the
+        descriptive article title), otherwise fall back to the longest
+        candidate. This avoids picking bare site names (e.g. Medium's second
+        <title>Medium</title>).
+        """
+        if len(candidates) == 1:
+            return candidates[0]
+        filter_regex = re.compile(r'[^\u4e00-\u9fa5a-zA-Z0-9\ ]')
+        og_filtered = filter_regex.sub('', og_title or '').lower().strip()
+        if og_filtered:
+            for candidate in candidates:
+                if og_filtered in filter_regex.sub('', candidate).lower():
+                    return candidate
+        return max(candidates, key=len)
+
     def get_title(self, doc):
         """Fetch the article title and analyze it
 
@@ -265,8 +283,20 @@ class ContentExtractor(object):
             if not title_text:
                 return title
         else:
-            # title elem found
-            title_text = self.parser.getText(title_element[0])
+            # some sites (e.g. Medium) emit multiple <title> tags, one of which
+            # is a bare site name ("Medium"). Blindly taking the first element
+            # can yield the useless site name, so pick the best candidate:
+            # prefer the one matching og:title, otherwise the longest text.
+            title_candidates = [self.parser.getText(el).strip()
+                                for el in title_element]
+            title_candidates = [c for c in title_candidates if c]
+            if not title_candidates:
+                title_text = title_text_fb
+                if not title_text:
+                    return title
+            else:
+                title_text = self._choose_title_candidate(title_candidates,
+                                                          title_text_fb)
         used_delimeter = False
 
         # title from h1

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -12,11 +12,12 @@ __license__ = 'MIT'
 __copyright__ = 'Copyright 2014, Lucas Ou-Yang'
 
 import copy
+import json
 import logging
 import os.path
 import re
-import re
 from collections import defaultdict
+from datetime import datetime
 
 from dateutil.parser import parse as date_parser
 from tldextract import tldextract
@@ -26,6 +27,11 @@ from . import urls
 from .utils import StringReplacement, StringSplitter
 
 log = logging.getLogger(__name__)
+
+# Anchors the fields a partial date leaves unspecified. Without it dateutil
+# fills them from the current moment, which makes '2014/04' resolve to a
+# different day depending on when you run it.
+DATE_DEFAULT = datetime(1, 1, 1)
 
 MOTLEY_REPLACEMENT = StringReplacement("&#65533;", "")
 ESCAPED_FRAGMENT_REPLACEMENT = StringReplacement(
@@ -183,18 +189,18 @@ class ContentExtractor(object):
         def parse_date_str(date_str):
             if date_str:
                 try:
-                    return date_parser(date_str)
+                    # An explicit default matters more than it looks. Given
+                    # '2014/04' dateutil fills the missing day from TODAY, so
+                    # the same page yields a different date depending on when it
+                    # is parsed, and re-running an extraction silently moves the
+                    # answer. The 1st is the honest reading of a year-month.
+                    return date_parser(date_str, default=DATE_DEFAULT)
                 except (ValueError, OverflowError, AttributeError, TypeError):
-                    # near all parse failures are due to URL dates without a day
-                    # specifier, e.g. /2014/04/
                     return None
 
-        date_match = re.search(urls.STRICT_DATE_REGEX, url)
-        if date_match:
-            date_str = date_match.group(0)
-            datetime_obj = parse_date_str(date_str)
-            if datetime_obj:
-                return datetime_obj
+        datetime_obj = parse_date_str(self._get_url_date(url))
+        if datetime_obj:
+            return datetime_obj
 
         PUBLISH_DATE_TAGS = [
             {'attribute': 'property', 'value': 'rnews:datePublished',
@@ -219,6 +225,12 @@ class ContentExtractor(object):
              'content': 'datetime'},
             {'attribute': 'name', 'value': 'publish_date',
              'content': 'content'},
+            {'attribute': 'name', 'value': 'date',
+             'content': 'content'},
+            {'attribute': 'name', 'value': 'dc.date',
+             'content': 'content'},
+            {'attribute': 'name', 'value': 'dcterms.created',
+             'content': 'content'},
         ]
         for known_meta_tag in PUBLISH_DATE_TAGS:
             meta_tags = self.parser.getElementsByTag(
@@ -232,6 +244,114 @@ class ContentExtractor(object):
                 datetime_obj = parse_date_str(date_str)
                 if datetime_obj:
                     return datetime_obj
+
+        # Schema.org JSON-LD, which is where most modern site generators put the
+        # date and where none of the meta tags above will find it. Tried after
+        # them so no existing page changes its answer, and before the raw text
+        # heuristics because a declared datePublished beats a regex over prose.
+        datetime_obj = parse_date_str(self._get_ld_json_date(doc))
+        if datetime_obj:
+            return datetime_obj
+
+        # <time datetime="..."> is the plain-HTML way to say the same thing.
+        # Only a time element the document marks as the publication date counts:
+        # a bare <time> is as likely to be a comment timestamp or a reading time.
+        for time_tag in self.parser.getElementsByTag(doc, tag='time'):
+            if self.parser.getAttribute(time_tag, 'pubdate') is None and \
+                    'publish' not in (
+                        self.parser.getAttribute(time_tag, 'itemprop') or
+                        self.parser.getAttribute(time_tag, 'class') or ''
+                    ).lower():
+                continue
+            datetime_obj = parse_date_str(
+                self.parser.getAttribute(time_tag, 'datetime'))
+            if datetime_obj:
+                return datetime_obj
+
+        return None
+
+    def _get_url_date(self, url):
+        """Find a publication date in the URL path, or None.
+
+        This replaced a bare STRICT_DATE_REGEX search, which was wrong in both
+        directions.
+
+        It missed real dates: the regex captures the separators around the
+        match, so '/2014/04/' arrived as '2014/04/' and dateutil raises on the
+        trailing slash. Every year-month URL fell through, and a page with no
+        date metadata then had no date at all. The old comment blamed the
+        missing day specifier and sent everyone looking in the wrong place —
+        date_parser('2014/04') is fine, date_parser('2014/04/') is not.
+
+        And it invented dates that were not there, which is the worse
+        direction: 'kali-linux-2026-1-release' and a '...-2026-07-...' API
+        version both look like dates to a regex that scans anywhere in the
+        string. Those only ever parsed by accident, because the same trailing
+        separator that hid the real dates also hid them.
+
+        The discriminator is position, not shape. A date in a URL owns the start
+        of its path segment — '/2013/03/slug', '/2025-10-registry-directory' —
+        while a version buried in a slug does not.
+        """
+        segments = [seg for seg in urlparse(url).path.split('/') if seg]
+
+        for index, segment in enumerate(segments):
+            # '2013/03/slug' and '2013/03/04/slug': consecutive numeric
+            # segments, which is the shape almost every blog engine emits.
+            if re.fullmatch(r'(19|20)\d{2}', segment):
+                parts = [segment]
+                for following in segments[index + 1:index + 3]:
+                    if not re.fullmatch(r'\d{1,2}', following):
+                        break
+                    parts.append(following)
+                if len(parts) > 1:
+                    return '-'.join(parts)
+                continue
+
+            # '2025-10-registry-directory', '2026-08-21-the-new-experience':
+            # the date opens the segment and a slug follows it.
+            match = re.match(
+                r'(19|20)\d{2}[-_.](\d{1,2})([-_.](\d{1,2}))?(?![0-9])', segment)
+            if match:
+                return match.group(0).rstrip('-_.').replace('_', '-') \
+                    .replace('.', '-')
+
+        return None
+
+    def _get_ld_json_date(self, doc):
+        """Pull datePublished out of any schema.org JSON-LD block.
+
+        The payload is author-controlled, so every shape here is one seen in the
+        wild: a bare object, a list of them, or a @graph wrapper. Malformed JSON
+        is common enough that it must never propagate — a page with a broken
+        script block still has the other strategies.
+        """
+        def find_date(node):
+            if isinstance(node, dict):
+                for key in ('datePublished', 'dateCreated'):
+                    value = node.get(key)
+                    if isinstance(value, str) and value.strip():
+                        return value
+                for nested in node.values():
+                    found = find_date(nested)
+                    if found:
+                        return found
+            elif isinstance(node, list):
+                for item in node:
+                    found = find_date(item)
+                    if found:
+                        return found
+            return None
+
+        for script in self.parser.getElementsByTag(
+                doc, tag='script', attr='type', value='application/ld+json'):
+            try:
+                payload = json.loads(self.parser.getText(script))
+            except (ValueError, TypeError):
+                continue
+            found = find_date(payload)
+            if found:
+                return found
 
         return None
 

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 FAIL_ENCODING = 'ISO-8859-1'
 
 
-def get_request_kwargs(timeout, useragent, proxies, headers):
+def get_request_kwargs(timeout, useragent, proxies, headers, allow_redirects):
     """This Wrapper method exists b/c some values in req_kwargs dict
     are methods which need to be called every time we make a request
     """
@@ -29,7 +29,7 @@ def get_request_kwargs(timeout, useragent, proxies, headers):
         'headers': headers if headers else {'User-Agent': useragent},
         'cookies': cj(),
         'timeout': timeout,
-        'allow_redirects': True,
+        'allow_redirects': allow_redirects,
         'proxies': proxies
     }
 
@@ -55,12 +55,13 @@ def get_html_2XX_only(url, config=None, response=None):
     timeout = config.request_timeout
     proxies = config.proxies
     headers = config.headers
+    allow_redirects = config.allow_redirects
 
     if response is not None:
         return _get_html_from_response(response, config)
 
     response = requests.get(
-        url=url, **get_request_kwargs(timeout, useragent, proxies, headers))
+        url=url, **get_request_kwargs(timeout, useragent, proxies, headers, allow_redirects))
 
     html = _get_html_from_response(response, config)
 
@@ -107,7 +108,7 @@ class MRequest(object):
     def send(self):
         try:
             self.resp = requests.get(self.url, **get_request_kwargs(
-                self.timeout, self.useragent, self.proxies, self.headers))
+                self.timeout, self.useragent, self.proxies, self.headers, self.config.allow_redirects))
             if self.config.http_success_only:
                 self.resp.raise_for_status()
         except requests.exceptions.RequestException as e:

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -44,7 +44,7 @@ def get_html(url, config=None, response=None):
         return ''
 
 
-def get_html_2XX_only(url, config=None, response=None):
+def get_html_2XX_only(url, config=None, response=None, return_final_url=False):
     """Consolidated logic for http requests from newspaper. We handle error cases:
     - Attempt to find encoding of the html by using HTTP header. Fallback to
       'ISO-8859-1' if not provided.
@@ -58,17 +58,23 @@ def get_html_2XX_only(url, config=None, response=None):
     allow_redirects = config.allow_redirects
 
     if response is not None:
-        return _get_html_from_response(response, config)
+        html = _get_html_from_response(response, config)
+        if return_final_url:
+            return html, getattr(response, 'url', url)
+        return html
 
     response = requests.get(
         url=url, **get_request_kwargs(timeout, useragent, proxies, headers, allow_redirects))
 
     html = _get_html_from_response(response, config)
+    final_url = response.url
 
     if config.http_success_only:
         # fail if HTTP sends a non 2XX response
         response.raise_for_status()
 
+    if return_final_url:
+        return html, final_url
     return html
 
 

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 FAIL_ENCODING = 'ISO-8859-1'
 
 
-def get_request_kwargs(timeout, useragent, proxies, headers, allow_redirects):
+def get_request_kwargs(timeout, useragent, proxies, headers, allow_redirects, verify_ssl_cert):
     """This Wrapper method exists b/c some values in req_kwargs dict
     are methods which need to be called every time we make a request
     """
@@ -30,7 +30,8 @@ def get_request_kwargs(timeout, useragent, proxies, headers, allow_redirects):
         'cookies': cj(),
         'timeout': timeout,
         'allow_redirects': allow_redirects,
-        'proxies': proxies
+        'proxies': proxies,
+        'verify': verify_ssl_cert,
     }
 
 
@@ -55,6 +56,7 @@ def get_html_2XX_only(url, config=None, response=None, return_final_url=False):
     timeout = config.request_timeout
     proxies = config.proxies
     headers = config.headers
+    verify_ssl_cert = config.verify_ssl_cert
     allow_redirects = config.allow_redirects
 
     if response is not None:
@@ -64,7 +66,7 @@ def get_html_2XX_only(url, config=None, response=None, return_final_url=False):
         return html
 
     response = requests.get(
-        url=url, **get_request_kwargs(timeout, useragent, proxies, headers, allow_redirects))
+        url=url, **get_request_kwargs(timeout, useragent, proxies, headers, allow_redirects, verify_ssl_cert))
 
     html = _get_html_from_response(response, config)
     final_url = response.url

--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -9,6 +9,7 @@ __copyright__ = 'Copyright 2014, Lucas Ou-Yang'
 
 from html import unescape
 import logging
+import copy
 
 from .text import innerTrim
 
@@ -42,7 +43,7 @@ class OutputFormatter(object):
         """Returns the body text of an article, and also the body article
         html if specified. Returns in (text, html) form
         """
-        self.top_node = top_node
+        self.top_node = copy.deepcopy(top_node)
         html, text = '', ''
 
         self.remove_negativescores_nodes()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cssselect>=0.9.2
 feedfinder2>=0.0.4
 feedparser>=5.2.1
 jieba3k>=0.35.1
-lxml>=3.6.0
+lxml==5.1.0 # https://lxml.de/5.2/changes-5.2.0.html
 nltk>=3.2.1
 Pillow>=3.3.0
 pythainlp>=1.7.2

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -24,7 +24,7 @@ HTML_FN = os.path.join(TEST_DIR, 'data', 'html')
 URLS_FILE = os.path.join(TEST_DIR, 'data', 'fulltext_url_list.txt')
 
 import newspaper
-from newspaper import Article, fulltext, Source, ArticleException, news_pool
+from newspaper import Article, Config, fulltext, Source, ArticleException, news_pool
 from newspaper.article import ArticleDownloadState
 from newspaper.configuration import Configuration
 from newspaper.urls import get_domain
@@ -406,9 +406,9 @@ class ContentExtractorTestCase(unittest.TestCase):
         html = '<meta property="og:image" content="https://example.com/meta_img_filename.jpg" />' \
                '<meta name="og:image" content="https://example.com/meta_another_img_filename.jpg"/>'
         html_empty_og_content = '<meta property="og:image" content="" />' \
-            '<meta name="og:image" content="https://example.com/meta_another_img_filename.jpg"/>'
+                                '<meta name="og:image" content="https://example.com/meta_another_img_filename.jpg"/>'
         html_empty_all = '<meta property="og:image" content="" />' \
-            '<meta name="og:image" />'
+                         '<meta name="og:image" />'
         html_rel_img_src = html_empty_all + '<link rel="img_src" href="https://example.com/meta_link_image.jpg" />'
         html_rel_img_src2 = html_empty_all + '<link rel="image_src" href="https://example.com/meta_link_image2.jpg" />'
         html_rel_icon = html_empty_all + '<link rel="icon" href="https://example.com/meta_link_rel_icon.ico" />'
@@ -544,7 +544,6 @@ class UrlTestCase(unittest.TestCase):
                 print('\t\turl: %s is supposed to be %s' % (url, truth_val))
                 raise
 
-
     @print_test
     def test_pubdate(self):
         """Checks that irrelevant data in url isn't considered as publishing date"""
@@ -567,7 +566,6 @@ class UrlTestCase(unittest.TestCase):
                     else:
                         print('\t\tpublishing date in %s should not be present' % (url))
                     raise
-
 
     @unittest.skip("Need to write an actual test")
     @print_test
@@ -635,9 +633,9 @@ class ConfigBuildTestCase(unittest.TestCase):
     NOTE: No need to mock responses as we are just initializing the
     objects, not actually calling download(..)
     """
+
     @print_test
     def test_article_default_params(self):
-
         a = Article(url='http://www.cnn.com/2013/11/27/'
                         'travel/weather-thanksgiving/index.html')
         self.assertEqual('en', a.config.language)
@@ -766,6 +764,19 @@ class TestDownloadPdf(unittest.TestCase):
         a = Article(url='https://www.adobe.com/pdf/pdfs/ISO32000-1PublicPatentLicense.pdf')
         a.download()
         self.assertNotEqual('%PDF-', a.html)
+
+
+class TestIgnoreImages(unittest.TestCase):
+
+    @print_test
+    def test_config_ignore_images(self):
+        config = Config()
+        config.ignored_images_suffix_list = ['think.png', '(.*)\.ico']
+        a = Article('https://www.reillywood.com/blog/why-nu/', config=config)
+        a.download()
+        a.parse()
+        self.assertEqual('https://d33wubrfki0l68.cloudfront.net/77d3013f91800257b3ca2adfb995ae24e49fff4e/b3086/img/main/headshot.jpg', a.top_img)
+
 
 if __name__ == '__main__':
     argv = list(sys.argv)

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -24,7 +24,7 @@ HTML_FN = os.path.join(TEST_DIR, 'data', 'html')
 URLS_FILE = os.path.join(TEST_DIR, 'data', 'fulltext_url_list.txt')
 
 import newspaper
-from newspaper import Article, Config, fulltext, Source, ArticleException, news_pool
+from newspaper import Article, Config, fulltext, Source, ArticleException, news_pool, images
 from newspaper.article import ArticleDownloadState
 from newspaper.configuration import Configuration
 from newspaper.urls import get_domain
@@ -776,6 +776,18 @@ class TestIgnoreImages(unittest.TestCase):
         a.download()
         a.parse()
         self.assertEqual('https://d33wubrfki0l68.cloudfront.net/77d3013f91800257b3ca2adfb995ae24e49fff4e/b3086/img/main/headshot.jpg', a.top_img)
+
+
+class TestGetImageDimensionFallback(unittest.TestCase):
+
+    @print_test
+    def test_get_image_dimension_fallback(self):
+        config = Config()
+        config.image_dimension_ration = 32 / 9
+        a = Article('https://appwrite.io/blog/post/add-figma-oauth2-appwrite', config=config)
+        s = images.Scraper(a)
+        sr = s.satisfies_requirements('https://appwrite.io/images/blog/add-figma-oauth2-appwrite/cover.png')
+        self.assertTrue(sr)
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -375,6 +375,10 @@ class ContentExtractorTestCase(unittest.TestCase):
         html = '<title>{}</title>'.format(title)
         self.assertEqual(self._get_title(html), title)
 
+    def test_get_title_fallback_to_og_title_when_title_missing(self):
+        html = '<meta property="og:title" content="Fallback title from og">'
+        self.assertEqual(self._get_title(html), 'Fallback title from og')
+
     def _get_canonical_link(self, article_url, html):
         doc = self.parser.fromstring(html)
         return self.extractor.get_canonical_link(article_url, doc)

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -448,6 +448,92 @@ class ContentExtractorTestCase(unittest.TestCase):
             'https://example.com/meta_link_rel_icon.ico'
         )
 
+    def _get_publishing_date(self, url, html='<html><body></body></html>'):
+        return self.extractor.get_publishing_date(
+            url, self.parser.fromstring(html))
+
+    def test_get_publishing_date_from_url(self):
+        # Year-month paths are the common case and used to yield nothing at all:
+        # the regex captured the trailing separator and dateutil raised on it.
+        for url, expected in [
+            ('https://firebase.blog/posts/2013/03/power-your-extension',
+             '2013-03-01 00:00:00'),
+            ('https://mypy-lang.blogspot.com/2024/10/mypy-113-released.html',
+             '2024-10-01 00:00:00'),
+            ('https://techcrunch.com/2026/08/21/some-post/',
+             '2026-08-21 00:00:00'),
+            ('https://rubyonrails.org/2026/8/21/this-week-in-rails',
+             '2026-08-21 00:00:00'),
+            ('https://ui.shadcn.com/docs/changelog/2025-10-registry-directory',
+             '2025-10-01 00:00:00'),
+            ('https://github.blog/changelog/2026-08-21-the-new-experience',
+             '2026-08-21 00:00:00'),
+        ]:
+            self.assertEqual(expected, str(self._get_publishing_date(url)), url)
+
+    def test_get_publishing_date_ignores_versions_in_a_slug(self):
+        # A date owns the start of its path segment; a version buried in a slug
+        # does not. These parsed only by accident before, via the same trailing
+        # separator that hid the real dates.
+        for url in [
+            'https://www.kali.org/blog/kali-linux-2026-1-release/',
+            'https://shopify.dev/changelog/some-thing-2026-07-api-change',
+            'https://istio.io/latest/blog/2026/some-post/',
+            'https://example.com/no-date-at-all/',
+        ]:
+            self.assertIsNone(self._get_publishing_date(url), url)
+
+    def test_get_publishing_date_pins_the_day_of_a_year_month(self):
+        # dateutil fills an unspecified day from TODAY, so this asserts the
+        # answer does not depend on the day the test runs.
+        date = self._get_publishing_date('https://x.dd/blog/2013/03/slug')
+        self.assertEqual(1, date.day)
+
+    def test_get_publishing_date_from_ld_json(self):
+        for html, expected in [
+            ('<script type="application/ld+json">'
+             '{"@type":"BlogPosting","datePublished":"2017-01-25"}</script>',
+             '2017-01-25 00:00:00'),
+            ('<script type="application/ld+json">'
+             '{"@graph":[{"@type":"WebSite"},{"datePublished":"2019-06-02"}]}'
+             '</script>', '2019-06-02 00:00:00'),
+            ('<script type="application/ld+json">'
+             '[{"@type":"Person"},{"datePublished":"2021-11-09"}]</script>',
+             '2021-11-09 00:00:00'),
+        ]:
+            self.assertEqual(
+                expected, str(self._get_publishing_date('https://x.dd/p', html)))
+
+    def test_get_publishing_date_survives_malformed_ld_json(self):
+        # The payload is author-controlled, so a broken block must not stop the
+        # remaining strategies.
+        html = '<script type="application/ld+json">{oops,</script>'
+        self.assertIsNone(self._get_publishing_date('https://x.dd/p', html))
+
+    def test_get_publishing_date_from_time_element(self):
+        self.assertEqual(
+            '2018-04-03 00:00:00',
+            str(self._get_publishing_date(
+                'https://x.dd/p',
+                '<time datetime="2018-04-03" pubdate="pubdate">x</time>')))
+        self.assertEqual(
+            '2020-02-02 00:00:00',
+            str(self._get_publishing_date(
+                'https://x.dd/p',
+                '<time itemprop="datePublished" datetime="2020-02-02">x</time>')))
+        # A bare <time> is as likely to be a reading time or a comment stamp.
+        self.assertIsNone(self._get_publishing_date(
+            'https://x.dd/p', '<time datetime="2020-02-02">5 min read</time>'))
+
+    def test_get_publishing_date_prefers_meta_over_the_new_strategies(self):
+        html = ('<meta property="article:published_time" content="2015-05-05"/>'
+                '<script type="application/ld+json">'
+                '{"datePublished":"2001-01-01"}</script>')
+        self.assertEqual(
+            '2015-05-05 00:00:00',
+            str(self._get_publishing_date('https://x.dd/p', html)))
+
+
 
 class SourceTestCase(unittest.TestCase):
     @print_test


### PR DESCRIPTION
## What

`get_publishing_date()` was wrong in **both** directions, and both faults trace to one line — it scanned the whole URL with `STRICT_DATE_REGEX`, which captures the separators around its match.

### It missed real dates

A `/2014/04/` path arrives as `2014/04/`, and `dateutil` raises on the trailing slash. Every year-month URL fell through to the metadata strategy, and a page without date metadata then ended up with **no date at all**.

The in-code comment blamed *"URL dates without a day specifier"*, which sent everyone looking in the wrong place:

```
parse('2014/04')   -> 2014-04-23    # fine
parse('2014/04/')  -> ParserError   # the actual failure
```

Replayed over 20 real year-month URLs from our corpus, the old code parsed **0 of 20**.

### It invented dates that were not there

The worse direction. `kali-linux-2026-1-release` and a Shopify `...-2026-07-...` API version both look like dates to a regex that scans anywhere in a string. They only ever came out right *by accident* — the same trailing separator that hid the real dates also hid them. Naively fixing the strip would have turned five accidental-correct nulls into five confident wrong dates.

**The discriminator is position, not shape.** A date in a URL owns the start of its path segment (`/2013/03/slug`, `/2025-10-registry-directory`); a version buried in a slug does not. `_get_url_date` walks path segments instead of scanning.

| URL | before | after |
|---|---|---|
| `firebase.blog/posts/2013/03/…` | — | 2013-03-01 |
| `mypy-lang.blogspot.com/2024/10/…` | — | 2024-10-01 |
| `ui.shadcn.com/docs/changelog/2025-10-registry-directory` | — | 2025-10-01 |
| `github.blog/changelog/2026-08-21-the-new-…` | — | 2026-08-21 |
| `techcrunch.com/2026/08/21/…` | 2026-08-21 | 2026-08-21 |
| `kali.org/blog/kali-linux-2026-1-release` | — | — |
| `shopify.dev/changelog/…-2026-07-…` | — | — |

## Metadata extraction

Adds schema.org **JSON-LD `datePublished`** (bare object, list, and `@graph` shapes; malformed JSON can never propagate), `<time>` elements the document *marks* as the publication date, and three more meta names (`date`, `dc.date`, `dcterms.created`).

Over 22 sampled pages that plainly state a date, the existing 11-tag list found **6**. JSON-LD is where most current site generators put it. A bare `<time>` is deliberately ignored — it is as likely to be a reading time or a comment stamp.

Both run **after** the existing tags, so no page that resolves a date today changes its answer. There's a test pinning that.

## Determinism

Partial dates are now anchored to an explicit `default`. Given `2014/04`, `dateutil` fills the missing day from **today**, so the same page yielded a different date depending on when it was parsed and a re-extraction silently moved the answer. A year-month now means the 1st.

## Why this matters downstream

daily.dev's claim ledger holds **11,080 claims dated from the day a page was crawled rather than published** — a page with no recoverable date leaves every consumer falling back to crawl time. That is harmless on a live feed and wrong by the article's whole age on an archive import (2022 articles drift four years). Two of the three ways a date goes missing are fixed here.

Related: dailydotdev/yggdrasil#725 (carry the feed's `<pubDate>` through, for pages that state no date anywhere) and dailydotdev/daily-api#4139 (stop the ledger dating a claim from crawl time).

## Tests

7 new tests covering both URL directions, the day-pinning, the three JSON-LD shapes, malformed JSON, `<time>`, and meta precedence. The suite goes 35 → 42 passing; the 8 pre-existing failures (missing nltk corpora, network-dependent image tests) are identical before and after.

## Note for whoever merges

`pyproject.toml` pins newspaper at `4e8b3f46` while `requirements.txt` pins `46fed320`, and the README says CI/CD uses `requirements.txt`. Those two need to move together, or the deploy will not pick this up.
